### PR TITLE
feat(inquiry): LP問い合わせフォームのCRUD実装 (issue#9)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -48,3 +48,10 @@ NEXTAUTH_SECRET=
 # SQUARE_APPLICATION_ID=your_square_application_id_here
 # SQUARE_LOCATION_ID=your_square_location_id_here
 # SQUARE_ENVIRONMENT=production
+
+# ==============================================
+# CORS configuration
+# ==============================================
+# LP問い合わせフォームの送信元オリジン（未設定時は "*" で全オリジン許可）
+# 本番では LP の正確なオリジンを指定してください
+ALLOWED_ORIGIN=https://yourdomain.com

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,10 @@ const nextConfig: NextConfig = {
       {
         source: "/api/inquiries",
         headers: [
-          { key: "Access-Control-Allow-Origin", value: "*" },
+          {
+            key: "Access-Control-Allow-Origin",
+            value: process.env.ALLOWED_ORIGIN ?? "*",
+          },
           { key: "Access-Control-Allow-Methods", value: "POST, OPTIONS" },
           { key: "Access-Control-Allow-Headers", value: "Content-Type" },
         ],

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,18 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/api/inquiries",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "Access-Control-Allow-Methods", value: "POST, OPTIONS" },
+          { key: "Access-Control-Allow-Headers", value: "Content-Type" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: "Access-Control-Allow-Origin",
+            // ローカル/ステージング: 未設定で "*" 許容、本番: LPオリジンを指定
             value: process.env.ALLOWED_ORIGIN ?? "*",
           },
           { key: "Access-Control-Allow-Methods", value: "POST, OPTIONS" },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,3 +15,16 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 }
+
+model Inquiry {
+  id           Int      @id @default(autoincrement())
+  facilityName String
+  contactName  String
+  email        String
+  phone        String?
+  facilityType String?
+  hasPc        String?
+  message      String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}

--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -617,9 +617,11 @@
         formData.forEach(function(value, key) { inquiry[key] = value; });
 
         var submitBtn = form.querySelector('button[type="submit"]');
-        var originalText = submitBtn.textContent;
-        submitBtn.disabled = true;
-        submitBtn.textContent = '送信中...';
+        var originalText = submitBtn ? submitBtn.textContent : '';
+        if (submitBtn) {
+          submitBtn.disabled = true;
+          submitBtn.textContent = '送信中...';
+        }
 
         fetch(API_URL, {
           method: 'POST',
@@ -635,21 +637,26 @@
             thanksDiv.classList.remove('hidden');
           } else {
             errorsDiv.textContent = '';
-            result.data.errors.forEach(function(msg) {
+            var errors = result.data && result.data.errors ? result.data.errors : ['送信に失敗しました'];
+            errors.forEach(function(msg) {
               var p = document.createElement('p');
               p.textContent = msg;
               errorsDiv.appendChild(p);
             });
             errorsDiv.classList.remove('hidden');
-            submitBtn.disabled = false;
-            submitBtn.textContent = originalText;
+            if (submitBtn) {
+              submitBtn.disabled = false;
+              submitBtn.textContent = originalText;
+            }
           }
         })
         .catch(function() {
           errorsDiv.textContent = '送信に失敗しました。時間をおいて再度お試しください。';
           errorsDiv.classList.remove('hidden');
-          submitBtn.disabled = false;
-          submitBtn.textContent = originalText;
+          if (submitBtn) {
+            submitBtn.disabled = false;
+            submitBtn.textContent = originalText;
+          }
         });
       });
     })();

--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -605,6 +605,7 @@
       var form = document.getElementById('inquiry-form');
       var errorsDiv = document.getElementById('inquiry-errors');
       var thanksDiv = document.getElementById('inquiry-thanks');
+      if (!form || !errorsDiv || !thanksDiv) return;
 
       form.addEventListener('submit', function(e) {
         e.preventDefault();

--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -598,5 +598,61 @@
     document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
   </script>
 
+  <!-- Inquiry form submission -->
+  <script>
+    (function() {
+      var API_URL = '/api/inquiries';
+      var form = document.getElementById('inquiry-form');
+      var errorsDiv = document.getElementById('inquiry-errors');
+      var thanksDiv = document.getElementById('inquiry-thanks');
+
+      form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        errorsDiv.classList.add('hidden');
+        errorsDiv.textContent = '';
+
+        var formData = new FormData(form);
+        var inquiry = {};
+        formData.forEach(function(value, key) { inquiry[key] = value; });
+
+        var submitBtn = form.querySelector('button[type="submit"]');
+        var originalText = submitBtn.textContent;
+        submitBtn.disabled = true;
+        submitBtn.textContent = '送信中...';
+
+        fetch(API_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ inquiry: inquiry })
+        })
+        .then(function(res) {
+          return res.json().then(function(data) { return { ok: res.ok, data: data }; });
+        })
+        .then(function(result) {
+          if (result.ok) {
+            form.classList.add('hidden');
+            thanksDiv.classList.remove('hidden');
+          } else {
+            errorsDiv.textContent = '';
+            result.data.errors.forEach(function(msg) {
+              var p = document.createElement('p');
+              p.textContent = msg;
+              errorsDiv.appendChild(p);
+            });
+            errorsDiv.classList.remove('hidden');
+            submitBtn.disabled = false;
+            submitBtn.textContent = originalText;
+          }
+        })
+        .catch(function() {
+          errorsDiv.textContent = '送信に失敗しました。時間をおいて再度お試しください。';
+          errorsDiv.classList.remove('hidden');
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+        });
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -2,10 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { FACILITY_TYPES, HAS_PC_OPTIONS } from "@/lib/inquiry-constants";
 
+const MESSAGE_MAX_LENGTH = 5000;
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const data = body.inquiry ?? body;
+    const data = body.inquiry;
+
+    if (!data) {
+      return NextResponse.json(
+        { errors: ["リクエスト形式が正しくありません"] },
+        { status: 422 }
+      );
+    }
 
     const errors: string[] = [];
 
@@ -25,6 +34,13 @@ export async function POST(request: NextRequest) {
     }
     if (data.has_pc && !HAS_PC_OPTIONS.includes(data.has_pc)) {
       errors.push("PC保有状況が正しくありません");
+    }
+    if (
+      data.message &&
+      typeof data.message === "string" &&
+      data.message.length > MESSAGE_MAX_LENGTH
+    ) {
+      errors.push(`ご相談内容は${MESSAGE_MAX_LENGTH}文字以内で入力してください`);
     }
 
     if (errors.length > 0) {
@@ -51,21 +67,11 @@ export async function POST(request: NextRequest) {
       },
       { status: 201 }
     );
-  } catch {
+  } catch (e) {
+    console.error("[POST /api/inquiries]", e);
     return NextResponse.json(
       { errors: ["サーバーエラーが発生しました"] },
       { status: 500 }
     );
   }
-}
-
-export async function OPTIONS() {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type",
-    },
-  });
 }

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const FACILITY_TYPES = [
+  "minpaku",
+  "simple_lodging",
+  "ryokan",
+  "hotel",
+  "other",
+];
+const HAS_PC_OPTIONS = ["mac", "windows", "other_pc", "no"];
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const data = body.inquiry ?? body;
+
+  const errors: string[] = [];
+
+  if (!data.facility_name?.trim()) {
+    errors.push("施設名を入力してください");
+  }
+  if (!data.contact_name?.trim()) {
+    errors.push("お名前を入力してください");
+  }
+  if (!data.email?.trim()) {
+    errors.push("メールアドレスを入力してください");
+  } else if (!/^[^@\s]+@[^@\s]+$/.test(data.email)) {
+    errors.push("メールアドレスの形式が正しくありません");
+  }
+  if (data.facility_type && !FACILITY_TYPES.includes(data.facility_type)) {
+    errors.push("施設の種類が正しくありません");
+  }
+  if (data.has_pc && !HAS_PC_OPTIONS.includes(data.has_pc)) {
+    errors.push("PC保有状況が正しくありません");
+  }
+
+  if (errors.length > 0) {
+    return NextResponse.json({ errors }, { status: 422 });
+  }
+
+  const inquiry = await prisma.inquiry.create({
+    data: {
+      facilityName: data.facility_name.trim(),
+      contactName: data.contact_name.trim(),
+      email: data.email.trim(),
+      phone: data.phone?.trim() || null,
+      facilityType: data.facility_type || null,
+      hasPc: data.has_pc || null,
+      message: data.message?.trim() || null,
+    },
+  });
+
+  return NextResponse.json(
+    {
+      message:
+        "お問い合わせありがとうございます。内容を確認の上、ご連絡いたします。",
+      id: inquiry.id,
+    },
+    { status: 201 }
+  );
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -1,63 +1,62 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-
-const FACILITY_TYPES = [
-  "minpaku",
-  "simple_lodging",
-  "ryokan",
-  "hotel",
-  "other",
-];
-const HAS_PC_OPTIONS = ["mac", "windows", "other_pc", "no"];
+import { FACILITY_TYPES, HAS_PC_OPTIONS } from "@/lib/inquiry-constants";
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const data = body.inquiry ?? body;
+  try {
+    const body = await request.json();
+    const data = body.inquiry ?? body;
 
-  const errors: string[] = [];
+    const errors: string[] = [];
 
-  if (!data.facility_name?.trim()) {
-    errors.push("施設名を入力してください");
-  }
-  if (!data.contact_name?.trim()) {
-    errors.push("お名前を入力してください");
-  }
-  if (!data.email?.trim()) {
-    errors.push("メールアドレスを入力してください");
-  } else if (!/^[^@\s]+@[^@\s]+$/.test(data.email)) {
-    errors.push("メールアドレスの形式が正しくありません");
-  }
-  if (data.facility_type && !FACILITY_TYPES.includes(data.facility_type)) {
-    errors.push("施設の種類が正しくありません");
-  }
-  if (data.has_pc && !HAS_PC_OPTIONS.includes(data.has_pc)) {
-    errors.push("PC保有状況が正しくありません");
-  }
+    if (!data.facility_name?.trim()) {
+      errors.push("施設名を入力してください");
+    }
+    if (!data.contact_name?.trim()) {
+      errors.push("お名前を入力してください");
+    }
+    if (!data.email?.trim()) {
+      errors.push("メールアドレスを入力してください");
+    } else if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(data.email)) {
+      errors.push("メールアドレスの形式が正しくありません");
+    }
+    if (data.facility_type && !FACILITY_TYPES.includes(data.facility_type)) {
+      errors.push("施設の種類が正しくありません");
+    }
+    if (data.has_pc && !HAS_PC_OPTIONS.includes(data.has_pc)) {
+      errors.push("PC保有状況が正しくありません");
+    }
 
-  if (errors.length > 0) {
-    return NextResponse.json({ errors }, { status: 422 });
+    if (errors.length > 0) {
+      return NextResponse.json({ errors }, { status: 422 });
+    }
+
+    const inquiry = await prisma.inquiry.create({
+      data: {
+        facilityName: data.facility_name.trim(),
+        contactName: data.contact_name.trim(),
+        email: data.email.trim(),
+        phone: data.phone?.trim() || null,
+        facilityType: data.facility_type || null,
+        hasPc: data.has_pc || null,
+        message: data.message?.trim() || null,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        message:
+          "お問い合わせありがとうございます。内容を確認の上、ご連絡いたします。",
+        id: inquiry.id,
+      },
+      { status: 201 }
+    );
+  } catch {
+    return NextResponse.json(
+      { errors: ["サーバーエラーが発生しました"] },
+      { status: 500 }
+    );
   }
-
-  const inquiry = await prisma.inquiry.create({
-    data: {
-      facilityName: data.facility_name.trim(),
-      contactName: data.contact_name.trim(),
-      email: data.email.trim(),
-      phone: data.phone?.trim() || null,
-      facilityType: data.facility_type || null,
-      hasPc: data.has_pc || null,
-      message: data.message?.trim() || null,
-    },
-  });
-
-  return NextResponse.json(
-    {
-      message:
-        "お問い合わせありがとうございます。内容を確認の上、ご連絡いたします。",
-      id: inquiry.id,
-    },
-    { status: 201 }
-  );
 }
 
 export async function OPTIONS() {

--- a/src/app/inquiries/[id]/page.tsx
+++ b/src/app/inquiries/[id]/page.tsx
@@ -1,21 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
-
-const FACILITY_TYPE_LABELS: Record<string, string> = {
-  minpaku: "民泊（住宅宿泊事業）",
-  simple_lodging: "簡易宿所",
-  ryokan: "旅館",
-  hotel: "ホテル",
-  other: "その他",
-};
-
-const HAS_PC_LABELS: Record<string, string> = {
-  mac: "はい（Mac）",
-  windows: "はい（Windows）",
-  other_pc: "はい（その他）",
-  no: "いいえ",
-};
+import { FACILITY_TYPE_LABELS, HAS_PC_LABELS } from "@/lib/inquiry-constants";
 
 export default async function InquiryDetailPage({
   params,
@@ -23,8 +9,11 @@ export default async function InquiryDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const numericId = Number(id);
+  if (isNaN(numericId)) notFound();
+
   const inquiry = await prisma.inquiry.findUnique({
-    where: { id: Number(id) },
+    where: { id: numericId },
   });
 
   if (!inquiry) notFound();

--- a/src/app/inquiries/[id]/page.tsx
+++ b/src/app/inquiries/[id]/page.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+
+const FACILITY_TYPE_LABELS: Record<string, string> = {
+  minpaku: "民泊（住宅宿泊事業）",
+  simple_lodging: "簡易宿所",
+  ryokan: "旅館",
+  hotel: "ホテル",
+  other: "その他",
+};
+
+const HAS_PC_LABELS: Record<string, string> = {
+  mac: "はい（Mac）",
+  windows: "はい（Windows）",
+  other_pc: "はい（その他）",
+  no: "いいえ",
+};
+
+export default async function InquiryDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const inquiry = await prisma.inquiry.findUnique({
+    where: { id: Number(id) },
+  });
+
+  if (!inquiry) notFound();
+
+  return (
+    <div className="w-full max-w-2xl mx-auto px-6 py-10">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">お問い合わせ詳細</h1>
+        <Link href="/inquiries" className="text-blue-600 hover:underline">
+          一覧に戻る
+        </Link>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-lg p-6 space-y-4">
+        <dl className="grid grid-cols-1 gap-4 text-sm">
+          <div>
+            <dt className="font-medium text-gray-500">受信日時</dt>
+            <dd className="mt-1">
+              {inquiry.createdAt.toLocaleDateString("ja-JP")}
+              {" "}
+              {inquiry.createdAt.toLocaleTimeString("ja-JP", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </dd>
+          </div>
+
+          <div>
+            <dt className="font-medium text-gray-500">施設名</dt>
+            <dd className="mt-1">{inquiry.facilityName}</dd>
+          </div>
+
+          <div>
+            <dt className="font-medium text-gray-500">担当者名</dt>
+            <dd className="mt-1">{inquiry.contactName}</dd>
+          </div>
+
+          <div>
+            <dt className="font-medium text-gray-500">メールアドレス</dt>
+            <dd className="mt-1">
+              <a href={`mailto:${inquiry.email}`} className="text-blue-600 hover:underline">
+                {inquiry.email}
+              </a>
+            </dd>
+          </div>
+
+          {inquiry.phone && (
+            <div>
+              <dt className="font-medium text-gray-500">電話番号</dt>
+              <dd className="mt-1">{inquiry.phone}</dd>
+            </div>
+          )}
+
+          {inquiry.facilityType && (
+            <div>
+              <dt className="font-medium text-gray-500">施設の種類</dt>
+              <dd className="mt-1">
+                {FACILITY_TYPE_LABELS[inquiry.facilityType] ?? inquiry.facilityType}
+              </dd>
+            </div>
+          )}
+
+          {inquiry.hasPc && (
+            <div>
+              <dt className="font-medium text-gray-500">PC保有状況</dt>
+              <dd className="mt-1">
+                {HAS_PC_LABELS[inquiry.hasPc] ?? inquiry.hasPc}
+              </dd>
+            </div>
+          )}
+
+          {inquiry.message && (
+            <div>
+              <dt className="font-medium text-gray-500">ご相談内容</dt>
+              <dd className="mt-1 whitespace-pre-wrap">{inquiry.message}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/src/app/inquiries/[id]/page.tsx
+++ b/src/app/inquiries/[id]/page.tsx
@@ -32,11 +32,14 @@ export default async function InquiryDetailPage({
           <div>
             <dt className="font-medium text-gray-500">受信日時</dt>
             <dd className="mt-1">
-              {inquiry.createdAt.toLocaleDateString("ja-JP")}
+              {inquiry.createdAt.toLocaleDateString("ja-JP", {
+                timeZone: "Asia/Tokyo",
+              })}
               {" "}
               {inquiry.createdAt.toLocaleTimeString("ja-JP", {
                 hour: "2-digit",
                 minute: "2-digit",
+                timeZone: "Asia/Tokyo",
               })}
             </dd>
           </div>

--- a/src/app/inquiries/page.tsx
+++ b/src/app/inquiries/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+
+const FACILITY_TYPE_LABELS: Record<string, string> = {
+  minpaku: "民泊（住宅宿泊事業）",
+  simple_lodging: "簡易宿所",
+  ryokan: "旅館",
+  hotel: "ホテル",
+  other: "その他",
+};
+
+export default async function InquiriesPage() {
+  const inquiries = await prisma.inquiry.findMany({
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="w-full max-w-6xl mx-auto px-6 py-10">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">お問い合わせ一覧</h1>
+      </div>
+
+      {inquiries.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b-2 border-gray-300">
+                <th className="text-left py-3 px-2">受信日時</th>
+                <th className="text-left py-3 px-2">施設名</th>
+                <th className="text-left py-3 px-2">担当者名</th>
+                <th className="text-left py-3 px-2">メール</th>
+                <th className="text-left py-3 px-2">施設種類</th>
+                <th className="text-left py-3 px-2">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {inquiries.map((inquiry) => (
+                <tr key={inquiry.id} className="border-b border-gray-200">
+                  <td className="py-3 px-2">
+                    {inquiry.createdAt.toLocaleDateString("ja-JP")}{" "}
+                    {inquiry.createdAt.toLocaleTimeString("ja-JP", {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </td>
+                  <td className="py-3 px-2">{inquiry.facilityName}</td>
+                  <td className="py-3 px-2">{inquiry.contactName}</td>
+                  <td className="py-3 px-2">{inquiry.email}</td>
+                  <td className="py-3 px-2">
+                    {inquiry.facilityType
+                      ? FACILITY_TYPE_LABELS[inquiry.facilityType] ?? inquiry.facilityType
+                      : ""}
+                  </td>
+                  <td className="py-3 px-2">
+                    <Link
+                      href={`/inquiries/${inquiry.id}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      詳細
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-gray-500">お問い合わせはまだありません。</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/inquiries/page.tsx
+++ b/src/app/inquiries/page.tsx
@@ -5,6 +5,7 @@ import { FACILITY_TYPE_LABELS } from "@/lib/inquiry-constants";
 export default async function InquiriesPage() {
   const inquiries = await prisma.inquiry.findMany({
     orderBy: { createdAt: "desc" },
+    take: 100,
   });
 
   return (
@@ -30,10 +31,13 @@ export default async function InquiriesPage() {
               {inquiries.map((inquiry) => (
                 <tr key={inquiry.id} className="border-b border-gray-200">
                   <td className="py-3 px-2">
-                    {inquiry.createdAt.toLocaleDateString("ja-JP")}{" "}
+                    {inquiry.createdAt.toLocaleDateString("ja-JP", {
+                      timeZone: "Asia/Tokyo",
+                    })}{" "}
                     {inquiry.createdAt.toLocaleTimeString("ja-JP", {
                       hour: "2-digit",
                       minute: "2-digit",
+                      timeZone: "Asia/Tokyo",
                     })}
                   </td>
                   <td className="py-3 px-2">{inquiry.facilityName}</td>

--- a/src/app/inquiries/page.tsx
+++ b/src/app/inquiries/page.tsx
@@ -1,13 +1,6 @@
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
-
-const FACILITY_TYPE_LABELS: Record<string, string> = {
-  minpaku: "民泊（住宅宿泊事業）",
-  simple_lodging: "簡易宿所",
-  ryokan: "旅館",
-  hotel: "ホテル",
-  other: "その他",
-};
+import { FACILITY_TYPE_LABELS } from "@/lib/inquiry-constants";
 
 export default async function InquiriesPage() {
   const inquiries = await prisma.inquiry.findMany({

--- a/src/lib/inquiry-constants.ts
+++ b/src/lib/inquiry-constants.ts
@@ -1,0 +1,24 @@
+export const FACILITY_TYPES = [
+  "minpaku",
+  "simple_lodging",
+  "ryokan",
+  "hotel",
+  "other",
+] as const;
+
+export const HAS_PC_OPTIONS = ["mac", "windows", "other_pc", "no"] as const;
+
+export const FACILITY_TYPE_LABELS: Record<string, string> = {
+  minpaku: "民泊（住宅宿泊事業）",
+  simple_lodging: "簡易宿所",
+  ryokan: "旅館",
+  hotel: "ホテル",
+  other: "その他",
+};
+
+export const HAS_PC_LABELS: Record<string, string> = {
+  mac: "はい（Mac）",
+  windows: "はい（Windows）",
+  other_pc: "はい（その他）",
+  no: "いいえ",
+};

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary

- Prisma に Inquiry モデルを追加
- `POST /api/inquiries` API Route を実装（バリデーション・try-catch・CORS対応）
- 管理画面（`/inquiries` 一覧、`/inquiries/[id]` 詳細）を Server Component で実装
- LP `index.html` にフォーム送信スクリプトを追加
- 定数（施設種類・PC保有ラベル）を `inquiry-constants.ts` に集約
- CORS設定を `next.config.ts` に統一、オリジンを環境変数 `ALLOWED_ORIGIN` で制御可能に
- 日時表示のタイムゾーンを `Asia/Tokyo` に明示
- `message` フィールドに5000文字上限を追加
- 一覧取得に `take: 100` の上限を設定
- フロント側の null チェック・エラーハンドリングを強化

### セキュリティ関連（別Issue切り出し済み）
- #10 管理画面に認証を追加
- #11 CORS制限とレート制限を追加

Closes #9

## Test plan

- [ ] `POST /api/inquiries` に正常なデータを送信し、201レスポンスが返ること
- [ ] 必須フィールド未入力で422 + エラーメッセージが返ること
- [ ] 不正なメールアドレス（ドットなし等）でバリデーションエラーになること
- [ ] 不正なJSONリクエストで500ではなくエラーレスポンスが返ること
- [ ] `{ inquiry: {...} }` 以外の形式で422が返ること
- [ ] `message` が5000文字超で422が返ること
- [ ] LP `index.html` からフォーム送信が動作すること
- [ ] APIがerrorsフィールドを返さない場合でもフロントがクラッシュしないこと
- [ ] `/inquiries` で一覧が表示されること（日時がJSTで表示されること）
- [ ] `/inquiries/[id]` で詳細が表示されること
- [ ] `/inquiries/abc` 等の不正IDで404が返ること
- [ ] `prisma migrate dev` でマイグレーションが正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)