### PR TITLE
feat(auth): 管理画面にBasic認証を追加 (issue#10)

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -37,3 +37,10 @@ SQUARE_ACCESS_TOKEN=your_square_access_token_here
 SQUARE_APPLICATION_ID=your_square_application_id_here
 SQUARE_LOCATION_ID=your_square_location_id_here
 SQUARE_ENVIRONMENT=sandbox
+
+# ==============================================
+# Admin authentication (管理画面 Basic認証)
+# /inquiries 配下のページを保護します
+# ==============================================
+ADMIN_USER=admin
+ADMIN_PASSWORD=admin

--- a/.env.production.example
+++ b/.env.production.example
@@ -55,3 +55,11 @@ NEXTAUTH_SECRET=
 # LP問い合わせフォームの送信元オリジン（未設定時は "*" で全オリジン許可）
 # 本番では LP の正確なオリジンを指定してください
 ALLOWED_ORIGIN=https://yourdomain.com
+
+# ==============================================
+# Admin authentication (管理画面 Basic認証)
+# /inquiries 配下のページを保護します
+# 本番では強固なパスワードを設定してください
+# ==============================================
+ADMIN_USER=admin
+ADMIN_PASSWORD=

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,35 +1,59 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export function middleware(request: NextRequest) {
-  const authorization = request.headers.get("authorization");
+function safeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBuf = encoder.encode(a);
+  const bBuf = encoder.encode(b);
+  const len = Math.max(aBuf.length, bBuf.length);
+  let result = aBuf.length ^ bBuf.length;
+  for (let i = 0; i < len; i++) {
+    result |= (aBuf[i] ?? 0) ^ (bBuf[i] ?? 0);
+  }
+  return result === 0;
+}
 
+const UNAUTHORIZED = new NextResponse(null, {
+  status: 401,
+  headers: { "WWW-Authenticate": 'Basic realm="Admin"' },
+});
+
+export function middleware(request: NextRequest) {
   const expectedUser = process.env.ADMIN_USER;
   const expectedPass = process.env.ADMIN_PASSWORD;
 
   if (!expectedUser || !expectedPass) {
-    return NextResponse.json(
-      { error: "認証が設定されていません" },
-      { status: 500 }
-    );
+    return new NextResponse(null, { status: 500 });
   }
 
-  if (authorization) {
-    const [scheme, encoded] = authorization.split(" ");
-    if (scheme === "Basic" && encoded) {
-      const decoded = atob(encoded);
-      const [user, pass] = decoded.split(":");
-      if (user === expectedUser && pass === expectedPass) {
-        return NextResponse.next();
-      }
-    }
+  const authorization = request.headers.get("authorization");
+  if (!authorization) return UNAUTHORIZED;
+
+  const spaceIndex = authorization.indexOf(" ");
+  if (spaceIndex === -1) return UNAUTHORIZED;
+
+  const scheme = authorization.slice(0, spaceIndex);
+  const encoded = authorization.slice(spaceIndex + 1);
+
+  if (scheme.toLowerCase() !== "basic" || !encoded) return UNAUTHORIZED;
+
+  let decoded: string;
+  try {
+    decoded = atob(encoded);
+  } catch {
+    return UNAUTHORIZED;
   }
 
-  return new NextResponse(null, {
-    status: 401,
-    headers: {
-      "WWW-Authenticate": 'Basic realm="Admin"',
-    },
-  });
+  const colonIndex = decoded.indexOf(":");
+  if (colonIndex === -1) return UNAUTHORIZED;
+
+  const user = decoded.slice(0, colonIndex);
+  const pass = decoded.slice(colonIndex + 1);
+
+  if (safeEqual(user, expectedUser) && safeEqual(pass, expectedPass)) {
+    return NextResponse.next();
+  }
+
+  return UNAUTHORIZED;
 }
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const authorization = request.headers.get("authorization");
+
+  const expectedUser = process.env.ADMIN_USER;
+  const expectedPass = process.env.ADMIN_PASSWORD;
+
+  if (!expectedUser || !expectedPass) {
+    return NextResponse.json(
+      { error: "認証が設定されていません" },
+      { status: 500 }
+    );
+  }
+
+  if (authorization) {
+    const [scheme, encoded] = authorization.split(" ");
+    if (scheme === "Basic" && encoded) {
+      const decoded = atob(encoded);
+      const [user, pass] = decoded.split(":");
+      if (user === expectedUser && pass === expectedPass) {
+        return NextResponse.next();
+      }
+    }
+  }
+
+  return new NextResponse(null, {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="Admin"',
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/inquiries/:path*"],
+};


### PR DESCRIPTION
## Summary

- `/inquiries` 配下のページを Next.js middleware で Basic 認証保護
- 認証情報は環境変数 `ADMIN_USER` / `ADMIN_PASSWORD` で制御
- Edge Runtime 互換の定数時間比較（`safeEqual`）でタイミング攻撃対策
- RFC 7617 準拠: コロン含むパスワード対応、scheme の case-insensitive 比較
- 不正な Base64 ヘッダーに対する適切なエラーハンドリング
- `.env.development.example` / `.env.production.example` に設定項目を追記

Closes #10

## Test plan

- [ ] `ADMIN_USER` / `ADMIN_PASSWORD` 未設定時に `/inquiries` で 500 が返ること
- [ ] 認証なしで `/inquiries` にアクセスすると 401 + Basic認証ダイアログが表示されること
- [ ] 正しい認証情報で `/inquiries` にアクセスできること
- [ ] 誤った認証情報で 401 が返ること
- [ ] `/inquiries/[id]` も同様に保護されること
- [ ] `/api/inquiries`（POST）は認証なしでアクセスできること（LPからの送信用）
- [ ] コロンを含むパスワードでも認証が動作すること
- [ ] 不正な Base64 ヘッダーで 401 が返ること（500 にならないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)