### PR TITLE
feat(inquiry): honeypotスパム対策を追加 (issue#14)

### DIFF
--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -506,7 +506,16 @@
           お気軽にお問い合わせください。
         </p>
       </div>
-      <form action="#" method="POST" class="reveal space-y-5" novalidate>
+      <div id="inquiry-thanks" class="hidden text-center py-16 reveal visible">
+        <div class="text-5xl mb-4">&#10003;</div>
+        <h3 class="text-2xl font-bold text-white mb-4">お問い合わせありがとうございます</h3>
+        <p class="text-ocean-200/80">内容を確認の上、ご連絡いたします。</p>
+      </div>
+      <form id="inquiry-form" method="POST" class="reveal space-y-5" novalidate>
+        <div id="inquiry-errors" class="hidden rounded-xl border border-red-400/50 bg-red-900/30 p-4 text-sm text-red-200"></div>
+        <div style="position:absolute;left:-9999px;" aria-hidden="true">
+          <input type="text" name="website" tabindex="-1" autocomplete="off">
+        </div>
         <div class="grid md:grid-cols-2 gap-5">
           <div>
             <label for="facility-name" class="block text-sm font-medium text-ocean-300 mb-2">施設名 <span class="text-coral-400">*</span></label>

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -16,6 +16,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (data.website) {
+      return NextResponse.json(
+        {
+          message:
+            "お問い合わせありがとうございます。内容を確認の上、ご連絡いたします。",
+        },
+        { status: 201 }
+      );
+    }
+
     const errors: string[] = [];
 
     if (!data.facility_name?.trim()) {


### PR DESCRIPTION
## 概要

問い合わせAPIにhoneypotフィールドによるBot検知を追加し、LPフォームのHTML要素不足を修正。

## 変更内容

- `POST /api/inquiries` に honeypot フィールド（`website`）チェックを追加（Bot検知時は201を返すがDB保存しない）
- LP `index.html` に honeypot の hidden フィールドを追加
- LP `index.html` にフォーム id 属性・エラー表示 div・完了メッセージ div を追加（JSスクリプトとの整合性修正）

## テスト方法

```bash
# honeypot発動: 201が返るがDBに保存されない
curl -X POST http://localhost:3000/api/inquiries \
  -H "Content-Type: application/json" \
  -d '{"inquiry":{"facility_name":"テスト","contact_name":"太郎","email":"test@example.com","website":"http://spam.com"}}'

# 通常送信: 201が返りDBに保存される
curl -X POST http://localhost:3000/api/inquiries \
  -H "Content-Type: application/json" \
  -d '{"inquiry":{"facility_name":"テスト","contact_name":"太郎","email":"test@example.com"}}'
```

## チェックリスト

- [ ] honeypot フィールドに値がある場合、DBに保存されないこと
- [ ] honeypot フィールドが空の場合、通常通りDB保存されること
- [ ] LP からのフォーム送信が正常に動作すること
- [ ] honeypot フィールドが通常ユーザーに表示されないこと

Closes #14