### PR TITLE
feat(lp): okinawa-lodging-tax LP デプロイ前の最終調整 (issue#25)

### DIFF
--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -15,7 +15,7 @@
   <meta property="og:url" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/">
   <!-- <meta property="og:image" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/ogp.png"> -->
   <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
   <meta name="twitter:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
   <link rel="preconnect" href="https://cdn.tailwindcss.com">

--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -3,9 +3,21 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex, nofollow">
   <meta name="theme-color" content="#071c22">
   <title>沖縄県宿泊税 対応支援システム｜2027年2月施行</title>
+  <meta name="description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
+  <link rel="icon" href="/favicon.ico">
+  <!-- OGP -->
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
+  <meta property="og:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
+  <meta property="og:url" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/">
+  <!-- <meta property="og:image" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/ogp.png"> -->
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
+  <meta name="twitter:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
   <link rel="preconnect" href="https://cdn.tailwindcss.com">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -513,6 +525,9 @@
       </div>
       <form id="inquiry-form" method="POST" class="reveal space-y-5" novalidate>
         <div id="inquiry-errors" class="hidden rounded-xl border border-red-400/50 bg-red-900/30 p-4 text-sm text-red-200"></div>
+        <div style="position:absolute;left:-9999px;" aria-hidden="true">
+          <input type="text" name="website" tabindex="-1" autocomplete="off">
+        </div>
         <div class="grid md:grid-cols-2 gap-5">
           <div>
             <label for="facility-name" class="block text-sm font-medium text-ocean-300 mb-2">施設名 <span class="text-coral-400">*</span></label>
@@ -587,7 +602,7 @@
   <!-- フッター -->
   <footer class="bg-ocean-950 text-ocean-400 py-10">
     <div class="max-w-5xl mx-auto px-6 text-center">
-      <p class="text-sm">&copy; 2026 okinawa-lodging-tax. All rights reserved.</p>
+      <p class="text-sm">&copy; 2026 AI.LandBase. All rights reserved.</p>
     </div>
   </footer>
 
@@ -619,8 +634,13 @@
         errorsDiv.textContent = '';
 
         var formData = new FormData(form);
+        if (formData.get('website')) {
+          form.classList.add('hidden');
+          thanksDiv.classList.remove('hidden');
+          return;
+        }
         var inquiry = {};
-        formData.forEach(function(value, key) { inquiry[key] = value; });
+        formData.forEach(function(value, key) { if (key !== 'website') inquiry[key] = value; });
 
         var submitBtn = form.querySelector('button[type="submit"]');
         var originalText = submitBtn ? submitBtn.textContent : '';

--- a/public/lp/okinawa-lodging-tax/index.html
+++ b/public/lp/okinawa-lodging-tax/index.html
@@ -15,7 +15,7 @@
   <meta property="og:url" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/">
   <!-- <meta property="og:image" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/ogp.png"> -->
   <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
   <meta name="twitter:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
   <link rel="preconnect" href="https://cdn.tailwindcss.com">

--- a/public/lp/okinawa-lodging-tax/index.html
+++ b/public/lp/okinawa-lodging-tax/index.html
@@ -3,9 +3,21 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex, nofollow">
   <meta name="theme-color" content="#071c22">
   <title>沖縄県宿泊税 対応支援システム｜2027年2月施行</title>
+  <meta name="description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
+  <link rel="icon" href="/favicon.ico">
+  <!-- OGP -->
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
+  <meta property="og:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
+  <meta property="og:url" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/">
+  <!-- <meta property="og:image" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/ogp.png"> -->
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
+  <meta name="twitter:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
   <link rel="preconnect" href="https://cdn.tailwindcss.com">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -513,6 +525,9 @@
       </div>
       <form id="inquiry-form" method="POST" class="reveal space-y-5" novalidate>
         <div id="inquiry-errors" class="hidden rounded-xl border border-red-400/50 bg-red-900/30 p-4 text-sm text-red-200"></div>
+        <div style="position:absolute;left:-9999px;" aria-hidden="true">
+          <input type="text" name="website" tabindex="-1" autocomplete="off">
+        </div>
         <div class="grid md:grid-cols-2 gap-5">
           <div>
             <label for="facility-name" class="block text-sm font-medium text-ocean-300 mb-2">施設名 <span class="text-coral-400">*</span></label>
@@ -587,7 +602,7 @@
   <!-- フッター -->
   <footer class="bg-ocean-950 text-ocean-400 py-10">
     <div class="max-w-5xl mx-auto px-6 text-center">
-      <p class="text-sm">&copy; 2026 okinawa-lodging-tax. All rights reserved.</p>
+      <p class="text-sm">&copy; 2026 AI.LandBase. All rights reserved.</p>
     </div>
   </footer>
 
@@ -619,8 +634,13 @@
         errorsDiv.textContent = '';
 
         var formData = new FormData(form);
+        if (formData.get('website')) {
+          form.classList.add('hidden');
+          thanksDiv.classList.remove('hidden');
+          return;
+        }
         var inquiry = {};
-        formData.forEach(function(value, key) { inquiry[key] = value; });
+        formData.forEach(function(value, key) { if (key !== 'website') inquiry[key] = value; });
 
         var submitBtn = form.querySelector('button[type="submit"]');
         var originalText = submitBtn ? submitBtn.textContent : '';


### PR DESCRIPTION
## 概要

okinawa-lodging-tax LP を本番公開するための最終調整。

## 変更内容

- `noindex, nofollow` メタタグを削除
- `description`・OGP・Twitter Card メタタグを追加
- honeypot スパム対策フィールドを復元（クライアント側スキップ付き）
- favicon リンクを追加
- フッター著作権表記を `AI.LandBase` に変更

## テスト方法

```bash
# LP をブラウザで開いて表示確認
open public/lp/okinawa-lodging-tax/index.html

# メタタグの確認（ページソース表示）
# honeypot 動作確認（DevTools で website フィールドに値を入力して送信）
```

## チェックリスト

- [x] noindex 削除済み
- [x] SEO メタタグ設定済み
- [x] honeypot スパム対策適用済み
- [x] フッター著作権表記修正済み
- [x] projects/ と public/lp/ が同期済み

## 備考

- `og:image` は画像未用意のためコメントアウト中（後日対応）
- `canonical` タグは後日追加検討

Closes #25