### PR TITLE
ops(lp): Caddy と og:url を lodging-tax.ai-landbase.jp に更新 (issue#23)

### DIFF
--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -12,7 +12,7 @@
   <meta property="og:locale" content="ja_JP">
   <meta property="og:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
   <meta property="og:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
-  <meta property="og:url" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/">
+  <meta property="og:url" content="https://lodging-tax.ai-landbase.jp/lp/okinawa-lodging-tax/">
   <!-- <meta property="og:image" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/ogp.png"> -->
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">

--- a/public/lp/okinawa-lodging-tax/index.html
+++ b/public/lp/okinawa-lodging-tax/index.html
@@ -12,7 +12,7 @@
   <meta property="og:locale" content="ja_JP">
   <meta property="og:title" content="沖縄県宿泊税 対応支援システム｜2027年2月施行">
   <meta property="og:description" content="2027年2月施行の沖縄県宿泊税に対応。税額自動計算・帳簿管理・月次申告データ出力で、旅館・ホテル・民泊の宿泊税業務を効率化します。">
-  <meta property="og:url" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/">
+  <meta property="og:url" content="https://lodging-tax.ai-landbase.jp/lp/okinawa-lodging-tax/">
   <!-- <meta property="og:image" content="https://www.ai-landbase.jp/lp/okinawa-lodging-tax/ogp.png"> -->
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">

--- a/reverse-proxy/Caddyfile
+++ b/reverse-proxy/Caddyfile
@@ -1,5 +1,3 @@
-# ドメイン名とリバースプロキシ先を本番環境に合わせて変更してください
-# リバースプロキシ先は compose.production.yaml の nextjsapp サービス名を指定します
-yourdomain.com {
+lodging-tax.ai-landbase.jp {
 	reverse_proxy nextjsapp:3000
 }


### PR DESCRIPTION
## 概要

okinawa-lodging-tax LP の配信ドメインを `lodging-tax.ai-landbase.jp` に設定する。

## 変更内容

- `reverse-proxy/Caddyfile`: プレースホルダー `yourdomain.com` → `lodging-tax.ai-landbase.jp` に設定
- LP の `og:url` を `https://lodging-tax.ai-landbase.jp/lp/okinawa-lodging-tax/` に更新

## 前提条件

- GoDaddy で `lodging-tax` の A レコード（→ `85.131.246.152`）が設定済みであること
- VPS 上の `/srv/reverse-proxy/Caddyfile` にも同内容を反映すること

## テスト方法

```bash
# DNS 解決の確認
dig lodging-tax.ai-landbase.jp +short
# → 85.131.246.152

# デプロイ後にブラウザで確認
# https://lodging-tax.ai-landbase.jp/lp/okinawa-lodging-tax/
```

## チェックリスト

- [x] Caddyfile のドメイン設定
- [x] og:url の更新
- [x] projects/ と public/lp/ の同期

Closes #23