### PR TITLE
fix(lib): Square SDK v44 の API 変更に対応 (issue#21)

### DIFF
--- a/src/lib/square.ts
+++ b/src/lib/square.ts
@@ -1,13 +1,13 @@
-import { Client, Environment } from "square";
+import { SquareClient, SquareEnvironment } from "square";
 
 export const squareClient =
   process.env.SQUARE_ACCESS_TOKEN
-    ? new Client({
+    ? new SquareClient({
         token: process.env.SQUARE_ACCESS_TOKEN,
         environment:
           process.env.SQUARE_ENVIRONMENT === "production"
-            ? Environment.Production
-            : Environment.Sandbox,
+            ? SquareEnvironment.Production
+            : SquareEnvironment.Sandbox,
       })
     : null;
 


### PR DESCRIPTION
## 概要

Square SDK v44 で `Client` → `SquareClient`、`Environment` → `SquareEnvironment` にリネームされたことへの対応。本番ビルドが失敗していた。

## 変更内容

- `Client` → `SquareClient`
- `Environment` → `SquareEnvironment`

Ref #21