### PR TITLE
fix(docker): production ステージに prisma.config.ts をコピー (issue#21)

### DIFF
--- a/Dockerfile.nextjs
+++ b/Dockerfile.nextjs
@@ -87,6 +87,7 @@ COPY --from=production-builder --chown=nextjs:nextjs /app/.next/static ./.next/s
 COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=production-builder --chown=nextjs:nextjs /app/prisma ./prisma
+COPY --from=production-builder --chown=nextjs:nextjs /app/prisma.config.ts ./prisma.config.ts
 
 USER nextjs
 


### PR DESCRIPTION
## 概要

本番コンテナで `prisma migrate deploy` が `datasource.url property is required` エラーで失敗する問題を修正。

## 原因

Dockerfile の production ステージで `prisma/` ディレクトリはコピーしていたが、プロジェクトルートの `prisma.config.ts` がコピーされていなかった。Prisma 7 では `prisma.config.ts` から `datasource.url` を読むため、ファイルが存在しないとエラーになる。

## 変更内容

- production ステージに `prisma.config.ts` の COPY を追加

Ref #21