### PR TITLE
fix(docker): production ステージに prisma パッケージをコピー (issue#21)

### DIFF
--- a/Dockerfile.nextjs
+++ b/Dockerfile.nextjs
@@ -86,6 +86,7 @@ COPY --from=production-builder --chown=nextjs:nextjs /app/.next/static ./.next/s
 # Prisma クライアントをコピー（マイグレーション実行用）
 COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/prisma ./node_modules/prisma
 COPY --from=production-builder --chown=nextjs:nextjs /app/prisma ./prisma
 COPY --from=production-builder --chown=nextjs:nextjs /app/prisma.config.ts ./prisma.config.ts
 

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ prod-deploy: lp-sync ## 本番環境をデプロイ（LP同期→ビルド→再
 	docker compose -f compose.production.yaml --env-file .env.production build --no-cache
 	docker compose -f compose.production.yaml --env-file .env.production down
 	docker compose -f compose.production.yaml --env-file .env.production up -d
-	docker compose -f compose.production.yaml --env-file .env.production exec nextjsapp npx prisma migrate deploy
+	docker compose -f compose.production.yaml --env-file .env.production exec nextjsapp ./node_modules/.bin/prisma migrate deploy
 	@echo "✅ デプロイが完了しました"
 
 .PHONY: prod-logs


### PR DESCRIPTION
## 概要

本番コンテナで `prisma migrate deploy` 時に `Cannot find module 'prisma/config'` エラーで失敗する問題を修正。

## 原因

production ステージで `@prisma/client` と `.prisma` はコピーしていたが、CLI の `prisma` パッケージ自体がコピーされていなかった。`npx` がグローバルから prisma をダウンロードしても、ローカルの `prisma.config.ts` が参照する `prisma/config` モジュールが存在しないためエラーになっていた。

## 変更内容

- `node_modules/prisma` を production ステージにコピー
- Makefile: `npx prisma` → `./node_modules/.bin/prisma` に変更（グローバルダウンロード回避）

Ref #21