### PR TITLE
fix(docker): prisma CLI の実行パスを修正 (issue#21)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ prod-deploy: lp-sync ## 本番環境をデプロイ（LP同期→ビルド→再
 	docker compose -f compose.production.yaml --env-file .env.production build --no-cache
 	docker compose -f compose.production.yaml --env-file .env.production down
 	docker compose -f compose.production.yaml --env-file .env.production up -d
-	docker compose -f compose.production.yaml --env-file .env.production exec nextjsapp ./node_modules/.bin/prisma migrate deploy
+	docker compose -f compose.production.yaml --env-file .env.production exec nextjsapp node node_modules/prisma/build/index.js migrate deploy
 	@echo "✅ デプロイが完了しました"
 
 .PHONY: prod-logs


### PR DESCRIPTION
## 概要

production コンテナに `.bin` シンボリックリンクがコピーされないため、`node` で prisma CLI を直接実行するように変更。

Ref #21