### PR TITLE
fix(docker): production ステージで npm ci --omit=dev を実行 (issue#21)

### DIFF
--- a/Dockerfile.nextjs
+++ b/Dockerfile.nextjs
@@ -83,12 +83,14 @@ COPY --from=production-builder --chown=nextjs:nextjs /app/public ./public
 COPY --from=production-builder --chown=nextjs:nextjs /app/.next/standalone ./
 COPY --from=production-builder --chown=nextjs:nextjs /app/.next/static ./.next/static
 
-# Prisma クライアントをコピー（マイグレーション実行用）
-COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/@prisma ./node_modules/@prisma
-COPY --from=production-builder --chown=nextjs:nextjs /app/node_modules/prisma ./node_modules/prisma
+# Prisma 関連ファイルをコピー
 COPY --from=production-builder --chown=nextjs:nextjs /app/prisma ./prisma
 COPY --from=production-builder --chown=nextjs:nextjs /app/prisma.config.ts ./prisma.config.ts
+COPY --from=production-builder --chown=nextjs:nextjs /app/package.json ./package.json
+COPY --from=production-builder --chown=nextjs:nextjs /app/package-lock.json ./package-lock.json
+
+# 本番用依存関係をインストール（prisma CLI + @prisma/client + 全依存）
+RUN npm ci --omit=dev
 
 USER nextjs
 

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ prod-deploy: lp-sync ## 本番環境をデプロイ（LP同期→ビルド→再
 	docker compose -f compose.production.yaml --env-file .env.production build --no-cache
 	docker compose -f compose.production.yaml --env-file .env.production down
 	docker compose -f compose.production.yaml --env-file .env.production up -d
-	docker compose -f compose.production.yaml --env-file .env.production exec nextjsapp node node_modules/prisma/build/index.js migrate deploy
+	docker compose -f compose.production.yaml --env-file .env.production exec nextjsapp npx prisma migrate deploy
 	@echo "✅ デプロイが完了しました"
 
 .PHONY: prod-logs


### PR DESCRIPTION
## 概要

Prisma 7 の依存関係（`effect` 等）が個別コピーでは不足する問題を根本解決。

## 変更内容

- production ステージで `npm ci --omit=dev` を実行し、本番依存関係を丸ごとインストール
- 個別の `node_modules/.prisma`, `@prisma`, `prisma` コピーを削除
- Makefile: `npx prisma` に戻す（`.bin` が生成されるため）

Ref #21