### PR TITLE
ops(proxy): LP の index.html 配信用リライトルールを追加 (issue#21)

### DIFF
--- a/reverse-proxy/Caddyfile
+++ b/reverse-proxy/Caddyfile
@@ -1,3 +1,16 @@
 lodging-tax.ai-landbase.jp {
-	reverse_proxy nextjsapp:3000
+	@lp-no-slash path_regexp lp ^/lp/([^/]+)$
+	handle @lp-no-slash {
+		redir {uri}/ permanent
+	}
+
+	@lp-with-slash path_regexp lpdir ^/lp/([^/]+)/$
+	handle @lp-with-slash {
+		rewrite * {re.lpdir.0}index.html
+		reverse_proxy nextjsapp:3000
+	}
+
+	handle {
+		reverse_proxy nextjsapp:3000
+	}
 }


### PR DESCRIPTION
## 概要

VPS 上で適用済みの Caddy リライトルールをリポジトリに反映。

## 変更内容

Next.js standalone モードでは `public/` 配下のディレクトリアクセス時に `index.html` が自動解決されないため、Caddy 側で対応:

- `/lp/okinawa-lodging-tax` → `/lp/okinawa-lodging-tax/` に 301 リダイレクト
- `/lp/okinawa-lodging-tax/` → `/lp/okinawa-lodging-tax/index.html` にリライト

Closes #21
Closes #23