### PR TITLE
fix(lp): 問い合わせフォームのリクエストボディ形式を修正 (issue#35)

### DIFF
--- a/projects/okinawa-lodging-tax/index.html
+++ b/projects/okinawa-lodging-tax/index.html
@@ -652,7 +652,7 @@
         fetch(API_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ inquiry: inquiry })
+          body: JSON.stringify(inquiry)
         })
         .then(function(res) {
           return res.json().then(function(data) { return { ok: res.ok, data: data }; });

--- a/public/lp/okinawa-lodging-tax/index.html
+++ b/public/lp/okinawa-lodging-tax/index.html
@@ -652,7 +652,7 @@
         fetch(API_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ inquiry: inquiry })
+          body: JSON.stringify(inquiry)
         })
         .then(function(res) {
           return res.json().then(function(data) { return { ok: res.ok, data: data }; });


### PR DESCRIPTION
## 概要

- LP の問い合わせフォームが `{ "inquiry": { ... } }` とネストした JSON を送信していたが、Rails API はフラットな JSON を期待しており 422 エラーになっていた
- `JSON.stringify({ inquiry: inquiry })` → `JSON.stringify(inquiry)` に修正

## 対象ファイル

- `projects/okinawa-lodging-tax/index.html`
- `public/lp/okinawa-lodging-tax/index.html`

## テスト

- [x] `curl` でフラットな JSON を POST → 正常レスポンス確認済み

Closes #35