### PR TITLE
perf(docker): package-lock.json のハッシュ比較で npm install をスキップ (issue#4)

### DIFF
--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -22,7 +22,7 @@ services:
       target: development
       args:
         NODE_VERSION: ${NODE_VERSION}
-    command: bash -c "npm install && npx prisma generate && npm run dev"
+    command: bash /app/docker/entrypoint.sh
     volumes:
       - .:/app
       - node_modules:/app/node_modules

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# node_modules 内に保存することで、ボリューム削除時にハッシュも消え再インストールが走る
 HASH_FILE="/app/node_modules/.package-lock-hash"
 CURRENT_HASH=$(md5sum /app/package-lock.json | cut -d' ' -f1)
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+HASH_FILE="/app/node_modules/.package-lock-hash"
+CURRENT_HASH=$(md5sum /app/package-lock.json | cut -d' ' -f1)
+
+if [ -f "$HASH_FILE" ] && [ "$(cat "$HASH_FILE")" = "$CURRENT_HASH" ]; then
+  echo "📦 依存関係に変更なし、npm install をスキップ"
+else
+  echo "📦 依存関係が変更されています、npm install を実行..."
+  npm install
+  echo "$CURRENT_HASH" > "$HASH_FILE"
+fi
+
+npx prisma generate
+exec npm run dev


### PR DESCRIPTION
## 概要

開発コンテナ起動時に毎回実行されていた `npm install` を、`package-lock.json` のハッシュ比較によりスキップ可能にした。

## 変更内容

- `docker/entrypoint.sh` を新規作成: `package-lock.json` の MD5 ハッシュを `node_modules/.package-lock-hash` に保存・比較し、変更がなければ `npm install` をスキップ
- `compose.development.yaml` の `command` を `bash /app/docker/entrypoint.sh` に差し替え

## テスト方法

```bash
# 1回目の起動（npm install が実行される）
make up
docker compose -f compose.development.yaml --env-file .env.development logs nextjsapp | grep "📦"
# → "📦 依存関係が変更されています、npm install を実行..."

# コンテナ再起動（npm install がスキップされる）
make down && make up
docker compose -f compose.development.yaml --env-file .env.development logs nextjsapp | grep "📦"
# → "📦 依存関係に変更なし、npm install をスキップ"

# 依存関係を変更して再起動（npm install が再実行される）
# package.json に新しいパッケージを追加後
make down && make up
docker compose -f compose.development.yaml --env-file .env.development logs nextjsapp | grep "📦"
# → "📦 依存関係が変更されています、npm install を実行..."
```

## チェックリスト

- [x] 依存関係に変更がない場合、2回目以降の起動が高速になる
- [x] 新しい依存関係が追加された場合は自動的にインストールされる

Closes #4