### PR TITLE
perf(docker): prisma generate のスキップ最適化 (issue#42)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+# 開発環境（compose.development.yaml）専用。本番は Dockerfile のビルドステージで処理する。
 set -e
 
 # node_modules 内に保存することで、ボリューム削除時にハッシュも消え再インストールが走る
 HASH_FILE="/app/node_modules/.package-lock-hash"
+PRISMA_HASH_FILE="/app/node_modules/.prisma-schema-hash"
 CURRENT_HASH=$(md5sum /app/package-lock.json | cut -d' ' -f1)
 
 if [ -f "$HASH_FILE" ] && [ "$(cat "$HASH_FILE")" = "$CURRENT_HASH" ]; then
@@ -11,9 +13,9 @@ else
   echo "📦 依存関係が変更されています、npm install を実行..."
   npm install
   echo "$CURRENT_HASH" > "$HASH_FILE"
+  rm -f "$PRISMA_HASH_FILE"  # Prisma バージョン変更時に generate を強制
 fi
 
-PRISMA_HASH_FILE="/app/node_modules/.prisma-schema-hash"
 PRISMA_CURRENT_HASH=$(md5sum /app/prisma/schema.prisma | cut -d' ' -f1)
 
 if [ -f "$PRISMA_HASH_FILE" ] && [ "$(cat "$PRISMA_HASH_FILE")" = "$PRISMA_CURRENT_HASH" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,5 +13,15 @@ else
   echo "$CURRENT_HASH" > "$HASH_FILE"
 fi
 
-npx prisma generate
+PRISMA_HASH_FILE="/app/node_modules/.prisma-schema-hash"
+PRISMA_CURRENT_HASH=$(md5sum /app/prisma/schema.prisma | cut -d' ' -f1)
+
+if [ -f "$PRISMA_HASH_FILE" ] && [ "$(cat "$PRISMA_HASH_FILE")" = "$PRISMA_CURRENT_HASH" ]; then
+  echo "📦 Prisma スキーマに変更なし、prisma generate をスキップ"
+else
+  echo "📦 Prisma スキーマが変更されています、prisma generate を実行..."
+  npx prisma generate
+  echo "$PRISMA_CURRENT_HASH" > "$PRISMA_HASH_FILE"
+fi
+
 exec npm run dev


### PR DESCRIPTION
## 概要

`docker/entrypoint.sh` で毎回実行されていた `npx prisma generate` を、`prisma/schema.prisma` のハッシュ比較によりスキップ可能にした。

## 変更内容

- `docker/entrypoint.sh` に `schema.prisma` の MD5 ハッシュ比較ロジックを追加
- スキーマに変更がない場合は `prisma generate` をスキップ
- ハッシュは `node_modules/.prisma-schema-hash` に保存（#4 の `npm install` スキップと同じ方式）

## テスト方法

```bash
# 1回目の起動（prisma generate が実行される）
make up
docker compose -f compose.development.yaml --env-file .env.development logs nextjsapp | grep "Prisma"
# → "📦 Prisma スキーマが変更されています、prisma generate を実行..."

# コンテナ再起動（prisma generate がスキップされる）
make down && make up
docker compose -f compose.development.yaml --env-file .env.development logs nextjsapp | grep "Prisma"
# → "📦 Prisma スキーマに変更なし、prisma generate をスキップ"

# schema.prisma を変更して再起動（prisma generate が再実行される）
make down && make up
docker compose -f compose.development.yaml --env-file .env.development logs nextjsapp | grep "Prisma"
# → "📦 Prisma スキーマが変更されています、prisma generate を実行..."
```

## チェックリスト

- [x] スキーマに変更がない場合、prisma generate がスキップされる
- [x] スキーマが変更された場合は自動的に prisma generate が実行される

Closes #42