### PR TITLE
feat(corp): Phase 6-3 会社案内ページ実装（/about）

### DIFF
--- a/src/app/about/CompanyTable.tsx
+++ b/src/app/about/CompanyTable.tsx
@@ -1,14 +1,15 @@
-"use client";
+import { EmailText } from "@/components/layout/EmailText";
 
-import { useEffect, useState } from "react";
+type Row = {
+  label: string;
+  value: string;
+  isLink?: boolean;
+};
 
-const ROWS = [
+const ROWS: Row[] = [
   { label: "正式名称", value: "株式会社 AI.LandBase（アイランドベース）" },
   { label: "代表者", value: "末永壽蔵" },
-  {
-    label: "所在地",
-    value: "〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2",
-  },
+  { label: "所在地", value: "〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2" },
   { label: "設立", value: "2025 年 6 月 26 日" },
   { label: "資本金", value: "300 万円" },
   {
@@ -17,15 +18,9 @@ const ROWS = [
       "観光業向け AI ソリューションの開発・提供、経営支援コンサルティング、施設管理代行",
   },
   { label: "Web", value: "https://ai-landbase.jp/", isLink: true },
-] as const;
+];
 
 export function CompanyTable() {
-  const [email, setEmail] = useState<string | null>(null);
-
-  useEffect(() => {
-    setEmail(`${"info"}@${"ai-landbase.jp"}`);
-  }, []);
-
   return (
     <dl className="mx-auto max-w-[720px] divide-y divide-ink-200">
       {ROWS.map((row) => (
@@ -37,7 +32,7 @@ export function CompanyTable() {
             {row.label}
           </dt>
           <dd className="text-sm text-ink-900">
-            {"isLink" in row && row.isLink ? (
+            {row.isLink ? (
               <a
                 href={row.value}
                 className="text-ink-800 underline hover:text-ink-900"
@@ -56,7 +51,9 @@ export function CompanyTable() {
         <dt className="w-32 shrink-0 text-sm font-bold text-ink-700">
           メール
         </dt>
-        <dd className="text-sm text-ink-900">{email}</dd>
+        <dd className="text-sm text-ink-900">
+          <EmailText as="span" className="mt-0 text-ink-900" />
+        </dd>
       </div>
     </dl>
   );

--- a/src/app/about/CompanyTable.tsx
+++ b/src/app/about/CompanyTable.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const ROWS = [
+  { label: "正式名称", value: "株式会社 AI.LandBase（アイランドベース）" },
+  { label: "代表者", value: "末永壽蔵" },
+  {
+    label: "所在地",
+    value: "〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2",
+  },
+  { label: "設立", value: "2025 年 6 月 26 日" },
+  { label: "資本金", value: "300 万円" },
+  {
+    label: "事業内容",
+    value:
+      "観光業向け AI ソリューションの開発・提供、経営支援コンサルティング、施設管理代行",
+  },
+  { label: "Web", value: "https://ai-landbase.jp/", isLink: true },
+] as const;
+
+export function CompanyTable() {
+  const [email, setEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEmail(`${"info"}@${"ai-landbase.jp"}`);
+  }, []);
+
+  return (
+    <dl className="mx-auto max-w-[720px] divide-y divide-ink-200">
+      {ROWS.map((row) => (
+        <div
+          key={row.label}
+          className="flex flex-col gap-1 py-4 sm:flex-row sm:gap-4"
+        >
+          <dt className="w-32 shrink-0 text-sm font-bold text-ink-700">
+            {row.label}
+          </dt>
+          <dd className="text-sm text-ink-900">
+            {"isLink" in row && row.isLink ? (
+              <a
+                href={row.value}
+                className="text-ink-800 underline hover:text-ink-900"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {row.value}
+              </a>
+            ) : (
+              row.value
+            )}
+          </dd>
+        </div>
+      ))}
+      <div className="flex flex-col gap-1 py-4 sm:flex-row sm:gap-4">
+        <dt className="w-32 shrink-0 text-sm font-bold text-ink-700">
+          メール
+        </dt>
+        <dd className="text-sm text-ink-900">{email}</dd>
+      </div>
+    </dl>
+  );
+}

--- a/src/app/about/LeaderProfile.tsx
+++ b/src/app/about/LeaderProfile.tsx
@@ -1,0 +1,25 @@
+export function LeaderProfile() {
+  return (
+    <div className="mx-auto flex max-w-[720px] flex-col gap-8 md:flex-row md:items-start">
+      <div className="mx-auto h-40 w-40 shrink-0 rounded-full bg-gradient-to-br from-paper-sky to-ink-100 md:mx-0" />
+      <div>
+        <h3 className="text-xl font-bold">末永壽蔵</h3>
+        <p className="mt-1 text-sm text-ink-500">
+          すえなが としぞう / 代表取締役
+        </p>
+        <div className="mt-4 space-y-3 text-base leading-relaxed text-ink-600">
+          <p>
+            AI.LandBase
+            代表。沖縄県今帰仁村を拠点に、地域の観光業事業者が AI
+            テクノロジーを身近に活用できる環境づくりに取り組んでいます。
+          </p>
+          <p>
+            自らも宿泊施設「Ikigai
+            Stay」を運営し、AI Suite
+            を使った経営の実践者でもあります。テクノロジーと現場の距離を縮め、沖縄北部の観光業を次のステージへ導くことを目指しています。
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/about/LocationSection.tsx
+++ b/src/app/about/LocationSection.tsx
@@ -1,0 +1,32 @@
+import { Section } from "@/components/primitives/Section";
+import { SectionHeading } from "@/components/primitives/SectionHeading";
+
+export function LocationSection() {
+  return (
+    <Section>
+      <SectionHeading title="拠点紹介 — Ikigai Stay" />
+      <div className="mx-auto max-w-[720px]">
+        <div className="space-y-4 text-base leading-relaxed text-ink-600">
+          <p>
+            AI.LandBase の拠点「Ikigai Stay」は、沖縄県今帰仁村にある宿泊施設です。世界有数の長寿地域として知られる「ブルーゾーン」に位置し、自然に囲まれた環境の中で営業しています。
+          </p>
+          <p>
+            この施設では、LandBase AI Suite の全 10 ツールを日常的に運用しています。客室の価格調整から清掃スケジュール管理、経理処理まで——自分たちが毎日使いながら改善を重ねることで、現場で本当に役立つツールを育てています。
+          </p>
+          <p>
+            お客様にご提案するサービスは、すべてこの Ikigai Stay での実体験に裏付けられています。
+          </p>
+        </div>
+        <div className="mt-8">
+          <div
+            className="aspect-[16/9] rounded-lg bg-gradient-to-br from-paper-sky to-ink-100"
+            role="presentation"
+          />
+          <p className="mt-3 text-sm text-ink-500">
+            〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/app/about/MissionBlock.tsx
+++ b/src/app/about/MissionBlock.tsx
@@ -1,0 +1,19 @@
+type MissionBlockProps = {
+  eyebrow: string;
+  title: string;
+  body: string;
+};
+
+export function MissionBlock({ eyebrow, title, body }: MissionBlockProps) {
+  return (
+    <div className="mx-auto max-w-[720px]">
+      <p className="text-xs font-medium uppercase tracking-[0.08em] text-ink-500">
+        {eyebrow}
+      </p>
+      <h3 className="mt-2 text-xl font-bold leading-snug md:text-2xl">
+        {title}
+      </h3>
+      <p className="mt-3 text-base leading-relaxed text-ink-600">{body}</p>
+    </div>
+  );
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from "next";
+import { Hero } from "@/components/sections/Hero";
+import { Section } from "@/components/primitives/Section";
+import { SectionHeading } from "@/components/primitives/SectionHeading";
+import { CTASection } from "@/components/cta/CTASection";
+import { CompanyTable } from "./CompanyTable";
+import { MissionBlock } from "./MissionBlock";
+import { LeaderProfile } from "./LeaderProfile";
+import { LocationSection } from "./LocationSection";
+
+export const metadata: Metadata = {
+  title: "会社案内",
+  description:
+    "株式会社 AI.LandBase の会社概要・ミッション・ビジョン・拠点情報。沖縄県北部を拠点に、AI テクノロジーで観光業の経営を支援しています。",
+};
+
+const MISSIONS = [
+  {
+    eyebrow: "Purpose — 存在意義",
+    title: "AI と共に Payless なエコシステムを作る",
+    body: "AI の力で、誰もが無理なく使える仕組みを築いていきます。",
+  },
+  {
+    eyebrow: "Mission — 使命",
+    title: "沖縄北部の観光業に AI を届ける",
+    body: "沖縄県北部の観光業事業者（ホテル、飲食店、ツアー会社など）に AI テクノロジーの力を届け、データドリブンな経営への転換を支援することで、持続可能な観光産業の発展に貢献する。",
+  },
+  {
+    eyebrow: "Vision — 目指す姿",
+    title: "データと人間の知恵が融合する観光モデル地域へ",
+    body: "2030 年までに、沖縄県北部の全観光業事業者が AI を活用した戦略的経営を実践し、データと人間の知恵が融合した新しい観光エコシステムのモデル地域となる。",
+  },
+] as const;
+
+export default function AboutPage() {
+  return (
+    <>
+      {/* 1. Hero */}
+      <Hero
+        variant="soft"
+        headline="会社案内"
+        lead="AI.LandBase は、沖縄県北部を拠点に、AI テクノロジーで観光業の経営を支援する会社です。"
+      />
+
+      {/* 2. 会社概要 */}
+      <Section>
+        <SectionHeading title="会社概要" />
+        <CompanyTable />
+      </Section>
+
+      {/* 3. Mission / Vision / Purpose */}
+      <Section variant="alt" id="mission">
+        <SectionHeading title="ミッション・ビジョン" />
+        <div className="space-y-12">
+          {MISSIONS.map((item) => (
+            <MissionBlock key={item.eyebrow} {...item} />
+          ))}
+        </div>
+      </Section>
+
+      {/* 4. 拠点紹介 */}
+      <LocationSection />
+
+      {/* 5. 代表者紹介 */}
+      <Section>
+        <SectionHeading title="代表者紹介" />
+        <LeaderProfile />
+      </Section>
+
+      {/* 6. CTA */}
+      <CTASection />
+    </>
+  );
+}

--- a/src/components/layout/EmailText.tsx
+++ b/src/components/layout/EmailText.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { cn } from "@/lib/cn";
 
-export function EmailText() {
+type EmailTextProps = {
+  className?: string;
+  as?: "p" | "span";
+};
+
+export function EmailText({ className, as: Tag = "p" }: EmailTextProps) {
   const [email, setEmail] = useState<string | null>(null);
 
   useEffect(() => {
@@ -11,5 +17,5 @@ export function EmailText() {
 
   if (!email) return null;
 
-  return <p className="mt-2 text-sm text-ink-200">{email}</p>;
+  return <Tag className={cn("mt-2 text-sm text-ink-200", className)}>{email}</Tag>;
 }


### PR DESCRIPTION
## Summary

- handoff P3 と Phase 3 コピー原稿に基づき、会社案内ページ（`/about`）を実装
- 5 セクション構成:
  1. Hero（`variant="soft"`）— H1 + リード
  2. 会社概要 — `<dl>` 定義リストテーブル（メールは anti-scraping 対応）
  3. ミッション・ビジョン — Purpose / Mission / Vision の 3 ブロック（`#mission` アンカー）
  4. 拠点紹介 — Ikigai Stay 紹介文 + プレースホルダー画像
  5. 代表者紹介 — プロフィール + プレースホルダー写真
- EmailText コンポーネントを汎用化（`className` / `as` props 追加）
- CompanyTable を Server Component 化（メール行のみ Client Component）

### 新規ファイル（5 ファイル）

```
src/app/about/page.tsx
src/app/about/CompanyTable.tsx
src/app/about/MissionBlock.tsx
src/app/about/LeaderProfile.tsx
src/app/about/LocationSection.tsx
```

### 変更ファイル

```
src/components/layout/EmailText.tsx — className / as props を追加
```

## Test plan

- [x] `npm run build` がエラーなく完了する
- [x] 会社概要が `<dl>` / `<dt>` / `<dd>` でマークアップされている
- [x] メールアドレスが HTML ソースに露出しない
- [x] metadata（title / description）が設定されている
- [x] ブラウザで全セクションの表示確認
- [x] 375px / 768px / 1440px でレスポンシブ確認

Closes #59