### PR TITLE
feat(corp): Phase 6-5 お問い合わせページ実装 (issue#64)

### DIFF
--- a/src/app/contact/ContactDetails.tsx
+++ b/src/app/contact/ContactDetails.tsx
@@ -1,0 +1,29 @@
+import { EmailText } from "@/components/layout/EmailText";
+
+export function ContactDetails() {
+  return (
+    <div className="mx-auto grid max-w-[720px] gap-8 md:grid-cols-2">
+      {/* Email */}
+      <div>
+        <h3 className="text-sm font-bold text-ink-700">メールアドレス</h3>
+        <EmailText as="p" className="mt-2 text-base text-ink-900" />
+        <p className="mt-2 text-xs text-ink-500">
+          件名で内容を判別して、担当が確認します。
+        </p>
+      </div>
+
+      {/* Location */}
+      <div>
+        <h3 className="text-sm font-bold text-ink-700">所在地</h3>
+        <p className="mt-2 text-base leading-relaxed text-ink-900">
+          〒905-0412
+          <br />
+          沖縄県国頭郡今帰仁村湧川 852-2
+        </p>
+        <p className="mt-2 text-xs text-ink-500">
+          沖縄北部・Ikigai Stay（ブルーゾーン）が拠点です。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,7 +3,6 @@ import { Hero } from "@/components/sections/Hero";
 import { Section } from "@/components/primitives/Section";
 import { SectionHeading } from "@/components/primitives/SectionHeading";
 import { MailtoButton } from "@/components/cta/MailtoButton";
-import { EmailText } from "@/components/layout/EmailText";
 import { ContactDetails } from "./ContactDetails";
 
 export const metadata: Metadata = {
@@ -55,7 +54,8 @@ export default function ContactPage() {
 
       {/* 2. Intent buttons */}
       <Section>
-        <p className="mb-8 text-center text-sm font-medium text-ink-500">
+        <h2 className="sr-only">ご相談内容の選択</h2>
+        <p className="mb-10 text-center text-sm font-medium text-ink-500 md:mb-14">
           ご相談内容をお選びください
         </p>
         <div className="mx-auto grid max-w-[720px] gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -83,18 +83,14 @@ export default function ContactPage() {
 
       {/* 4. Approach */}
       <Section>
-        <div className="mx-auto max-w-[720px]">
-          <h3 className="text-lg font-bold text-ink-900">
-            お問い合わせから返信まで
-          </h3>
-          <div className="mt-4 space-y-3 text-sm leading-relaxed text-ink-600">
-            <p>
-              通常 2〜3 営業日以内に担当者よりご返信いたします。内容によってはお時間をいただく場合があります。
-            </p>
-            <p>
-              ご相談はすべて秘密厳守で対応いたします。検討段階のふわっとしたご相談も歓迎です。
-            </p>
-          </div>
+        <SectionHeading title="お問い合わせから返信まで" />
+        <div className="mx-auto max-w-[720px] space-y-3 text-sm leading-relaxed text-ink-600">
+          <p>
+            通常 2〜3 営業日以内に担当者よりご返信いたします。内容によってはお時間をいただく場合があります。
+          </p>
+          <p>
+            ご相談はすべて秘密厳守で対応いたします。検討段階のふわっとしたご相談も歓迎です。
+          </p>
         </div>
       </Section>
     </>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next";
+import { Hero } from "@/components/sections/Hero";
+import { Section } from "@/components/primitives/Section";
+import { SectionHeading } from "@/components/primitives/SectionHeading";
+import { MailtoButton } from "@/components/cta/MailtoButton";
+import { EmailText } from "@/components/layout/EmailText";
+import { ContactDetails } from "./ContactDetails";
+
+export const metadata: Metadata = {
+  title: "お問い合わせ",
+  description:
+    "AI.LandBase へのお問い合わせ。サービスのご相談、宿泊税対応、自治体・行政からのご連絡など、お気軽にメールでご連絡ください。",
+};
+
+const INTENTS = [
+  {
+    label: "サービスについて相談したい",
+    subject: "[AI.LandBase] サービスに関するお問い合わせ",
+  },
+  {
+    label: "宿泊税対応について聞きたい",
+    subject: "[AI.LandBase] 宿泊税対応に関するお問い合わせ",
+  },
+  {
+    label: "自治体・行政からの連絡",
+    subject: "[AI.LandBase] 自治体・行政からのお問い合わせ",
+  },
+  {
+    label: "パートナー連携の相談",
+    subject: "[AI.LandBase] パートナー連携に関するお問い合わせ",
+  },
+  {
+    label: "取材・メディアのご依頼",
+    subject: "[AI.LandBase] 取材・メディアに関するお問い合わせ",
+  },
+  {
+    label: "採用について",
+    subject: "[AI.LandBase] 採用に関するお問い合わせ",
+  },
+  {
+    label: "その他のお問い合わせ",
+    subject: "[AI.LandBase] お問い合わせ",
+  },
+] as const;
+
+export default function ContactPage() {
+  return (
+    <>
+      {/* 1. Hero */}
+      <Hero
+        variant="soft"
+        headline="お問い合わせ"
+        lead="AI.LandBase へのご連絡は、メールにて承っています。ご相談内容に近いボタンをお選びください。お気軽にどうぞ。"
+      />
+
+      {/* 2. Intent buttons */}
+      <Section>
+        <p className="mb-8 text-center text-sm font-medium text-ink-500">
+          ご相談内容をお選びください
+        </p>
+        <div className="mx-auto grid max-w-[720px] gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {INTENTS.map((intent) => (
+            <MailtoButton
+              key={intent.label}
+              variant="ghost"
+              subject={intent.subject}
+              fullWidth
+            >
+              {intent.label}
+            </MailtoButton>
+          ))}
+        </div>
+        <p className="mt-6 text-center text-xs text-ink-400">
+          件名はあらかじめ入力されます。本文に状況をご記入のうえご送信ください。
+        </p>
+      </Section>
+
+      {/* 3. Contact details */}
+      <Section variant="alt">
+        <SectionHeading title="連絡先" />
+        <ContactDetails />
+      </Section>
+
+      {/* 4. Approach */}
+      <Section>
+        <div className="mx-auto max-w-[720px]">
+          <h3 className="text-lg font-bold text-ink-900">
+            お問い合わせから返信まで
+          </h3>
+          <div className="mt-4 space-y-3 text-sm leading-relaxed text-ink-600">
+            <p>
+              通常 2〜3 営業日以内に担当者よりご返信いたします。内容によってはお時間をいただく場合があります。
+            </p>
+            <p>
+              ご相談はすべて秘密厳守で対応いたします。検討段階のふわっとしたご相談も歓迎です。
+            </p>
+          </div>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/src/components/layout/EmailText.tsx
+++ b/src/components/layout/EmailText.tsx
@@ -15,7 +15,7 @@ export function EmailText({ className, as: Tag = "p" }: EmailTextProps) {
     setEmail(`${"info"}@${"ai-landbase.jp"}`);
   }, []);
 
-  if (!email) return null;
+  if (!email) return <Tag className={cn("mt-2 text-sm text-ink-200", className)}>&nbsp;</Tag>;
 
   return <Tag className={cn("mt-2 text-sm text-ink-200", className)}>{email}</Tag>;
 }


### PR DESCRIPTION
## 概要
お問い合わせページ (`/contact`) を新規実装。フォームなし・mailto ベースの導線に統一。

## 変更内容
- `src/app/contact/page.tsx` — メインページ（4セクション: Hero / 件名テンプレート / 連絡先 / 返信目安）
- `src/app/contact/ContactDetails.tsx` — メールアドレス（JS合成）+ 所在地の2カラムレイアウト
- `src/components/layout/EmailText.tsx` — CLS 対策（null → プレースホルダーに変更）

## 技術的なポイント
- CTASection は意図的に省略（ページ全体が CTA のため）
- 全コンポーネント Server Component（EmailText / MailtoButton のみ Client）
- 件名テンプレート 7 種を ghost MailtoButton で提供
- セクション2 に sr-only の h2 を追加（a11y）
- セクション4 を SectionHeading に統一（見出し階層の一貫性）

## テスト計画
- [x] `npm run build` 成功
- [x] デスクトップ (1440px) で全4セクション表示確認
- [x] モバイル (375px) でレスポンシブ表示確認
- [x] コードレビュー完了

Closes #64