### PR TITLE
feat(corp): 法務ページ実装（/privacy, /tokushoho）

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Hero } from "@/components/sections/Hero";
 import { Section } from "@/components/primitives/Section";
+import { EmailText } from "@/components/layout/EmailText";
 
 export const metadata: Metadata = {
   title: "プライバシーポリシー",
@@ -136,6 +137,7 @@ export default function PrivacyPage() {
               本ポリシーに関するお問い合わせは、下記までご連絡ください。
             </p>
             <table className="mt-4 w-full text-left">
+              <caption className="sr-only">お問い合わせ先</caption>
               <tbody>
                 <tr className="border-b border-ink-200">
                   <th scope="row" className="py-2 pr-4 font-medium text-ink-900">
@@ -161,7 +163,9 @@ export default function PrivacyPage() {
                   <th scope="row" className="py-2 pr-4 font-medium text-ink-900">
                     メール
                   </th>
-                  <td className="py-2">info@ai-landbase.jp</td>
+                  <td className="py-2">
+                    <EmailText as="span" className="mt-0 text-sm text-ink-700" />
+                  </td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,175 @@
+import type { Metadata } from "next";
+import { Hero } from "@/components/sections/Hero";
+import { Section } from "@/components/primitives/Section";
+
+export const metadata: Metadata = {
+  title: "プライバシーポリシー",
+  description:
+    "株式会社 AI.LandBase のプライバシーポリシー。個人情報の取り扱いについてご説明します。",
+};
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <Hero
+        variant="soft"
+        headline="プライバシーポリシー"
+        lead="株式会社 AI.LandBase（以下「当社」）は、お客様の個人情報の保護を重要な責務と認識し、以下のとおりプライバシーポリシーを定めます。"
+      />
+
+      <Section>
+        <div className="mx-auto max-w-[720px] space-y-10 text-sm leading-relaxed text-ink-700">
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第1条（個人情報の定義）
+            </h2>
+            <p>
+              本ポリシーにおいて「個人情報」とは、個人情報の保護に関する法律（以下「個人情報保護法」）に定める個人情報を指し、氏名、メールアドレスその他の記述等により特定の個人を識別できる情報をいいます。
+            </p>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第2条（個人情報の収集方法）
+            </h2>
+            <p>当社は、以下の方法により個人情報を取得することがあります。</p>
+            <ul className="mt-3 list-disc space-y-1 pl-6">
+              <li>
+                メールでのお問い合わせ時に、お客様が提供する氏名・メールアドレス・ご相談内容
+              </li>
+              <li>
+                当社サービスのご契約時に、お客様が提供する会社名・氏名・住所・電話番号・メールアドレス等
+              </li>
+            </ul>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第3条（個人情報の利用目的）
+            </h2>
+            <p>当社は、取得した個人情報を以下の目的で利用します。</p>
+            <ul className="mt-3 list-disc space-y-1 pl-6">
+              <li>お問い合わせへの回答およびご連絡</li>
+              <li>サービスの提供・運営・改善</li>
+              <li>契約に関する事務手続き</li>
+              <li>新サービスや重要なお知らせのご案内</li>
+              <li>法令に基づく対応</li>
+            </ul>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第4条（個人情報の第三者提供）
+            </h2>
+            <p>
+              当社は、以下の場合を除き、お客様の同意なく個人情報を第三者に提供しません。
+            </p>
+            <ul className="mt-3 list-disc space-y-1 pl-6">
+              <li>法令に基づく場合</li>
+              <li>
+                人の生命・身体または財産の保護のために必要であり、本人の同意を得ることが困難な場合
+              </li>
+              <li>
+                公衆衛生の向上または児童の健全な育成の推進のために必要であり、本人の同意を得ることが困難な場合
+              </li>
+              <li>
+                国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合
+              </li>
+            </ul>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第5条（個人情報の安全管理）
+            </h2>
+            <p>
+              当社は、個人情報の漏えい・滅失・毀損の防止その他の安全管理のために、必要かつ適切な措置を講じます。
+            </p>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第6条（個人情報の開示・訂正・削除）
+            </h2>
+            <p>
+              お客様は、当社が保有するご自身の個人情報について、開示・訂正・削除を請求することができます。ご請求の際は、下記のお問い合わせ先までご連絡ください。本人確認のうえ、合理的な期間内に対応いたします。
+            </p>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第7条（Cookie の使用について）
+            </h2>
+            <p>
+              当社ウェブサイトでは、利用状況の把握やサービス改善を目的として、Cookie
+              およびこれに類する技術を使用する場合があります。Cookie
+              はお客様のブラウザ設定により無効にすることができますが、一部の機能が制限される場合があります。
+            </p>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第8条（アクセス解析ツール）
+            </h2>
+            <p>
+              当社ウェブサイトでは、Google LLC が提供する Google Analytics
+              を使用しています。Google Analytics は Cookie
+              を使用してお客様の利用状況を収集しますが、個人を特定する情報は含まれません。収集されたデータは
+              Google のプライバシーポリシーに基づき管理されます。
+            </p>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第9条（本ポリシーの変更）
+            </h2>
+            <p>
+              当社は、必要に応じて本ポリシーの内容を変更することがあります。変更後のポリシーは、当社ウェブサイトに掲載した時点から効力を生じるものとします。
+            </p>
+          </article>
+
+          <article>
+            <h2 className="mb-4 text-lg font-bold text-ink-900">
+              第10条（お問い合わせ先）
+            </h2>
+            <p>
+              本ポリシーに関するお問い合わせは、下記までご連絡ください。
+            </p>
+            <table className="mt-4 w-full text-left">
+              <tbody>
+                <tr className="border-b border-ink-200">
+                  <th scope="row" className="py-2 pr-4 font-medium text-ink-900">
+                    事業者名
+                  </th>
+                  <td className="py-2">株式会社 AI.LandBase</td>
+                </tr>
+                <tr className="border-b border-ink-200">
+                  <th scope="row" className="py-2 pr-4 font-medium text-ink-900">
+                    代表者
+                  </th>
+                  <td className="py-2">末永壽蔵</td>
+                </tr>
+                <tr className="border-b border-ink-200">
+                  <th scope="row" className="py-2 pr-4 font-medium text-ink-900">
+                    所在地
+                  </th>
+                  <td className="py-2">
+                    〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2
+                  </td>
+                </tr>
+                <tr className="border-b border-ink-200">
+                  <th scope="row" className="py-2 pr-4 font-medium text-ink-900">
+                    メール
+                  </th>
+                  <td className="py-2">info@ai-landbase.jp</td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+
+          <p className="pt-4 text-ink-500">制定日: 2025年6月26日</p>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/src/app/tokushoho/page.tsx
+++ b/src/app/tokushoho/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Hero } from "@/components/sections/Hero";
 import { Section } from "@/components/primitives/Section";
 import { SectionHeading } from "@/components/primitives/SectionHeading";
+import { EmailText } from "@/components/layout/EmailText";
 
 export const metadata: Metadata = {
   title: "特定商取引法に基づく表記",
@@ -10,11 +11,11 @@ export const metadata: Metadata = {
     "株式会社 AI.LandBase の特定商取引法に基づく表記。販売事業者情報、販売価格、支払方法、返品・キャンセルについてご確認いただけます。",
 };
 
-const DISCLOSURE_ITEMS = [
+const DISCLOSURE_ITEMS: { label: string; value: string | null }[] = [
   { label: "販売事業者", value: "株式会社 AI.LandBase" },
   { label: "代表者", value: "末永壽蔵" },
   { label: "所在地", value: "〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2" },
-  { label: "メールアドレス", value: "info@ai-landbase.jp" },
+  { label: "メールアドレス", value: null },
   {
     label: "電話番号",
     value: "ご請求いただいた方に遅滞なく開示いたします",
@@ -84,7 +85,11 @@ export default function TokushohoPage() {
                   >
                     {item.label}
                   </th>
-                  <td className="py-3 text-ink-700">{item.value}</td>
+                  <td className="py-3 text-ink-700">
+                    {item.value ?? (
+                      <EmailText as="span" className="mt-0 text-sm text-ink-700" />
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/app/tokushoho/page.tsx
+++ b/src/app/tokushoho/page.tsx
@@ -1,0 +1,151 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Hero } from "@/components/sections/Hero";
+import { Section } from "@/components/primitives/Section";
+import { SectionHeading } from "@/components/primitives/SectionHeading";
+
+export const metadata: Metadata = {
+  title: "特定商取引法に基づく表記",
+  description:
+    "株式会社 AI.LandBase の特定商取引法に基づく表記。販売事業者情報、販売価格、支払方法、返品・キャンセルについてご確認いただけます。",
+};
+
+const DISCLOSURE_ITEMS = [
+  { label: "販売事業者", value: "株式会社 AI.LandBase" },
+  { label: "代表者", value: "末永壽蔵" },
+  { label: "所在地", value: "〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2" },
+  { label: "メールアドレス", value: "info@ai-landbase.jp" },
+  {
+    label: "電話番号",
+    value: "ご請求いただいた方に遅滞なく開示いたします",
+  },
+  {
+    label: "販売価格",
+    value: "各サービスページに表示された価格に準じます",
+  },
+  {
+    label: "販売価格以外の必要料金",
+    value: "消費税（税別表示の場合）",
+  },
+  {
+    label: "支払方法",
+    value: "銀行振込 / クレジットカード決済（Square）",
+  },
+  {
+    label: "支払時期",
+    value:
+      "サービスにより異なります。詳細はご契約時にご案内いたします",
+  },
+  {
+    label: "役務の提供時期",
+    value: "お申し込み後、双方合意のうえ決定いたします",
+  },
+  {
+    label: "返品・キャンセルについて",
+    value:
+      "サービスの性質上、提供開始後の返品・返金はお受けしておりません。詳細はご契約前にご説明いたします",
+  },
+  {
+    label: "動作環境",
+    value:
+      "AI Suite Server プラン: macOS / iPadOS / インターネット接続環境が必要です",
+  },
+] as const;
+
+const PRICE_TABLE = [
+  { service: "スタンダードプラン", price: "月額 50,000 円" },
+  { service: "プロフェッショナルプラン", price: "個別見積" },
+  { service: "AI Suite Server プラン", price: "1,965,000 円（一式）" },
+] as const;
+
+export default function TokushohoPage() {
+  return (
+    <>
+      <Hero
+        variant="soft"
+        headline="特定商取引法に基づく表記"
+        lead="特定商取引法第11条（通信販売についての広告）に基づく表示事項です。"
+      />
+
+      {/* 表示事項 */}
+      <Section>
+        <div className="mx-auto max-w-[720px]">
+          <h2 className="sr-only">表示事項</h2>
+          <table className="w-full text-left text-sm">
+            <caption className="sr-only">
+              特定商取引法に基づく表示事項
+            </caption>
+            <tbody>
+              {DISCLOSURE_ITEMS.map((item) => (
+                <tr key={item.label} className="border-b border-ink-200">
+                  <th
+                    scope="row"
+                    className="w-[140px] py-3 pr-4 align-top font-medium text-ink-900 md:w-[200px]"
+                  >
+                    {item.label}
+                  </th>
+                  <td className="py-3 text-ink-700">{item.value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      {/* 補足 */}
+      <Section variant="alt">
+        <SectionHeading title="主なサービスと価格" />
+        <div className="mx-auto max-w-[720px]">
+          <table className="w-full text-left text-sm">
+            <caption className="sr-only">主なサービスと価格一覧</caption>
+            <thead>
+              <tr className="border-b border-ink-300">
+                <th scope="col" className="py-3 pr-4 font-medium text-ink-900">
+                  サービス
+                </th>
+                <th scope="col" className="py-3 font-medium text-ink-900">
+                  価格（税別）
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {PRICE_TABLE.map((row) => (
+                <tr key={row.service} className="border-b border-ink-200">
+                  <th
+                    scope="row"
+                    className="py-3 pr-4 font-normal text-ink-700"
+                  >
+                    {row.service}
+                  </th>
+                  <td className="py-3 text-ink-700">{row.price}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mt-4 text-xs text-ink-500">
+            ※
+            上記は本表記作成時点の価格です。最新の価格は
+            <Link
+              href="/services"
+              className="text-sea-600 underline hover:text-sea-700"
+            >
+              サービスページ
+            </Link>
+            をご確認ください。
+          </p>
+        </div>
+      </Section>
+
+      {/* 補助金について */}
+      <Section>
+        <SectionHeading title="補助金について" />
+        <div className="mx-auto max-w-[720px] text-sm leading-relaxed text-ink-700">
+          <p>
+            AI Suite Server
+            プランは、沖縄県の補助金制度を活用できる場合があります。補助金活用時の費用については個別にご案内いたします。
+          </p>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -108,6 +108,12 @@ export function Footer() {
               >
                 プライバシーポリシー
               </a>
+              <a
+                href="/tokushoho"
+                className="text-sm text-ink-200 transition-colors hover:text-paper-pure hover:underline"
+              >
+                特定商取引法に基づく表記
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- プライバシーポリシーページ（`/privacy`）を実装（全10条 + 制定日）
- 特定商取引法に基づく表記ページ（`/tokushoho`）を実装（表示事項12項目 + 価格表 + 補助金補足）
- フッターに `/tokushoho` リンクを追加
- 両ページのメールアドレスに `EmailText` によるスパム対策を適用

## Test plan
- [x] `/privacy` がコピー原稿どおりに表示される
- [x] `/tokushoho` がコピー原稿どおりに表示される
- [x] CTASection が表示されない
- [x] フッターに両ページへのリンクがある
- [x] 1440px / 375px でレスポンシブ表示が崩れない
- [x] 見出し階層が正しい（h1 → h2 → h3）

closes #68