### PR TITLE
fix(corp): Lighthouse Accessibility コントラスト比修正（全ページ100達成）

### DIFF
--- a/src/app/about/LeaderProfile.tsx
+++ b/src/app/about/LeaderProfile.tsx
@@ -3,7 +3,7 @@ export function LeaderProfile() {
     <div className="mx-auto max-w-[720px]">
       <div>
         <h3 className="text-xl font-bold">末永壽蔵</h3>
-        <p className="mt-1 text-sm text-ink-500">
+        <p className="mt-1 text-sm text-ink-600">
           すえなが としぞう / 代表取締役
         </p>
         <div className="mt-4 space-y-3 text-base leading-relaxed text-ink-600">

--- a/src/app/about/LocationSection.tsx
+++ b/src/app/about/LocationSection.tsx
@@ -22,7 +22,7 @@ export function LocationSection() {
             className="aspect-[16/9] rounded-lg bg-gradient-to-br from-paper-sky to-ink-100"
             role="presentation"
           />
-          <p className="mt-3 text-sm text-ink-500">
+          <p className="mt-3 text-sm text-ink-600">
             〒905-0412 沖縄県国頭郡今帰仁村湧川 852-2
           </p>
         </div>

--- a/src/app/about/MissionBlock.tsx
+++ b/src/app/about/MissionBlock.tsx
@@ -7,7 +7,7 @@ type MissionBlockProps = {
 export function MissionBlock({ eyebrow, title, body }: MissionBlockProps) {
   return (
     <div className="mx-auto max-w-[720px]">
-      <p className="text-xs font-medium uppercase tracking-[0.08em] text-ink-500">
+      <p className="text-xs font-medium uppercase tracking-[0.08em] text-ink-600">
         {eyebrow}
       </p>
       <h3 className="mt-2 text-xl font-bold leading-snug md:text-2xl">

--- a/src/app/contact/ContactDetails.tsx
+++ b/src/app/contact/ContactDetails.tsx
@@ -7,7 +7,7 @@ export function ContactDetails() {
       <div>
         <h3 className="text-sm font-bold text-ink-700">メールアドレス</h3>
         <EmailText as="p" className="mt-2 text-base text-ink-900" />
-        <p className="mt-2 text-xs text-ink-500">
+        <p className="mt-2 text-xs text-ink-600">
           件名で内容を判別して、担当が確認します。
         </p>
       </div>
@@ -20,7 +20,7 @@ export function ContactDetails() {
           <br />
           沖縄県国頭郡今帰仁村湧川 852-2
         </p>
-        <p className="mt-2 text-xs text-ink-500">
+        <p className="mt-2 text-xs text-ink-600">
           沖縄北部・Ikigai Stay（ブルーゾーン）が拠点です。
         </p>
       </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -55,7 +55,7 @@ export default function ContactPage() {
       {/* 2. Intent buttons */}
       <Section>
         <h2 className="sr-only">ご相談内容の選択</h2>
-        <p className="mb-10 text-center text-sm font-medium text-ink-500 md:mb-14">
+        <p className="mb-10 text-center text-sm font-medium text-ink-600 md:mb-14">
           ご相談内容をお選びください
         </p>
         <div className="mx-auto grid max-w-[720px] gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -70,7 +70,7 @@ export default function ContactPage() {
             </MailtoButton>
           ))}
         </div>
-        <p className="mt-6 text-center text-xs text-ink-400">
+        <p className="mt-6 text-center text-xs text-ink-600">
           件名はあらかじめ入力されます。本文に状況をご記入のうえご送信ください。
         </p>
       </Section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,7 +25,7 @@
   --color-plan-standard-soft: #E6F2EE;
   --color-plan-professional: #2E5C9E; /* AA 6.69:1 on white */
   --color-plan-professional-soft: #E4ECF7;
-  --color-plan-server: #A96522; /* AA 4.59:1 on white */
+  --color-plan-server: #8E541B; /* AA 5.38:1 on server-soft, 6.12:1 on white */
   --color-plan-server-soft: #FAEFE0;
 
   /* ---------- Colors: Brand accent ---------- */

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -171,7 +171,7 @@ export default function PrivacyPage() {
             </table>
           </article>
 
-          <p className="pt-4 text-ink-500">制定日: 2025年6月26日</p>
+          <p className="pt-4 text-ink-600">制定日: 2025年6月26日</p>
         </div>
       </Section>
     </>

--- a/src/app/services/AISuiteToolTile.tsx
+++ b/src/app/services/AISuiteToolTile.tsx
@@ -15,13 +15,13 @@ export function AISuiteToolTile({
 }: AISuiteToolTileProps) {
   return (
     <div className="rounded-lg border border-ink-200 bg-paper-pure p-4">
-      <p className="text-xs font-bold text-ink-400">
+      <p className="text-xs font-bold text-ink-600">
         {String(number).padStart(2, "0")}
       </p>
       <h3 className="mt-1 text-sm font-bold leading-snug text-ink-900">
         {name}
       </h3>
-      <p className="mt-0.5 text-xs text-ink-500">{tagline}</p>
+      <p className="mt-0.5 text-xs text-ink-600">{tagline}</p>
       <div className="mt-2 flex flex-wrap gap-1">
         {tags.map((tag) => (
           <span

--- a/src/app/services/DetailedPlanCard.tsx
+++ b/src/app/services/DetailedPlanCard.tsx
@@ -44,7 +44,7 @@ export function DetailedPlanCard({
       <p className="mt-2 text-2xl font-bold text-ink-900">
         {priceLabel}
         {priceNote && (
-          <span className="ml-1 text-sm font-normal text-ink-500">
+          <span className="ml-1 text-sm font-normal text-ink-600">
             {priceNote}
           </span>
         )}
@@ -97,7 +97,7 @@ export function DetailedPlanCard({
         </a>
       )}
 
-      <p className="mt-4 text-xs text-ink-500">
+      <p className="mt-4 text-xs text-ink-600">
         対象業種: {targetIndustry}
       </p>
 

--- a/src/app/services/SpotServiceTable.tsx
+++ b/src/app/services/SpotServiceTable.tsx
@@ -29,7 +29,7 @@ export function SpotServiceTable() {
           ))}
         </tbody>
       </table>
-      <p className="mt-3 text-xs text-ink-500">
+      <p className="mt-3 text-xs text-ink-600">
         ※上記は宿泊業向けの料金です。飲食・ツアー向けのスポット対応についてはお問い合わせください。
       </p>
     </div>

--- a/src/app/tokushoho/page.tsx
+++ b/src/app/tokushoho/page.tsx
@@ -127,7 +127,7 @@ export default function TokushohoPage() {
               ))}
             </tbody>
           </table>
-          <p className="mt-4 text-xs text-ink-500">
+          <p className="mt-4 text-xs text-ink-600">
             ※
             上記は本表記作成時点の価格です。最新の価格は
             <Link

--- a/src/components/primitives/SectionHeading.tsx
+++ b/src/components/primitives/SectionHeading.tsx
@@ -24,7 +24,7 @@ export function SectionHeading({
       )}
     >
       {eyebrow && (
-        <p className="mb-3 text-xs font-medium uppercase tracking-[0.08em] text-ink-500">
+        <p className="mb-3 text-xs font-medium uppercase tracking-[0.08em] text-ink-600">
           {eyebrow}
         </p>
       )}

--- a/src/components/sections/PlanCard.tsx
+++ b/src/components/sections/PlanCard.tsx
@@ -44,7 +44,7 @@ export function PlanCard({
       <p className="mt-2 text-2xl font-bold text-ink-900">
         {priceLabel}
         {priceNote && (
-          <span className="ml-1 text-sm font-normal text-ink-500">
+          <span className="ml-1 text-sm font-normal text-ink-600">
             {priceNote}
           </span>
         )}


### PR DESCRIPTION
## Summary
- `text-ink-500` → `text-ink-600` に全12ファイルで一括変更（白背景コントラスト比 4.15:1 → 6.02:1）
- `text-ink-400` → `text-ink-600` に白背景上の2箇所で変更（2.57:1 → 6.02:1）
- `--color-plan-server` を `#A96522` → `#8E541B` に変更（soft背景コントラスト比 4.04:1 → 5.38:1）

## Lighthouse 結果（修正後）

| ページ | Accessibility | SEO |
|--------|---------------|-----|
| `/` | 100 | 100 |
| `/services` | 100 | 100 |
| `/about` | 100 | 100 |
| `/contact` | 100 | 100 |
| `/privacy` | 100 | 100 |
| `/tokushoho` | 100 | 100 |

## Test plan
- [x] 全ページ Lighthouse Accessibility 100
- [x] 全ページ Lighthouse SEO 100
- [x] ビルド成功
- [x] Footer の `text-ink-400`（暗背景）は変更不要を確認済み（5.79:1）

closes #72