### PR TITLE
ops(corp): Caddyfile に ai-landbase.jp ルーティングを追加

### DIFF
--- a/reverse-proxy/Caddyfile
+++ b/reverse-proxy/Caddyfile
@@ -1,3 +1,7 @@
+ai-landbase.jp {
+	reverse_proxy nextjsapp:3000
+}
+
 lodging-tax.ai-landbase.jp {
 	@lp-no-slash path_regexp lp ^/lp/([^/]+)$
 	handle @lp-no-slash {


### PR DESCRIPTION
## Summary
- Caddyfile に `ai-landbase.jp` のリバースプロキシ設定を追加
- 既存の `lodging-tax.ai-landbase.jp` と同じ `nextjsapp:3000` にプロキシ

## Test plan
- [ ] サーバーで Caddy reload 後、`https://ai-landbase.jp` に SSL 接続できる
- [ ] 全ページが 200 を返す

refs #72