### PR TITLE
feat(services): AI Suite ツールタイルにアイコンを追加

### DIFF
--- a/src/app/services/AISuiteToolTile.tsx
+++ b/src/app/services/AISuiteToolTile.tsx
@@ -1,7 +1,35 @@
+import {
+  BarChart3,
+  BadgeJapaneseYen,
+  MessageCircle,
+  Heart,
+  Star,
+  Megaphone,
+  Settings,
+  Receipt,
+  Package,
+  GraduationCap,
+} from "lucide-react";
+import type { AISuiteToolIcon } from "./_data";
+
+const ICON_MAP = {
+  BarChart3,
+  BadgeJapaneseYen,
+  MessageCircle,
+  Heart,
+  Star,
+  Megaphone,
+  Settings,
+  Receipt,
+  Package,
+  GraduationCap,
+} as const satisfies Record<AISuiteToolIcon, React.ComponentType<{ size?: number; className?: string }>>;
+
 type AISuiteToolTileProps = {
   number: number;
   name: string;
   tagline: string;
+  icon: AISuiteToolIcon;
   tags: readonly string[];
   description: string;
 };
@@ -10,15 +38,21 @@ export function AISuiteToolTile({
   number,
   name,
   tagline,
+  icon,
   tags,
   description,
 }: AISuiteToolTileProps) {
+  const Icon = ICON_MAP[icon];
+
   return (
     <div className="rounded-lg border border-ink-200 bg-paper-pure p-4">
-      <p className="text-xs font-bold text-ink-600">
-        {String(number).padStart(2, "0")}
-      </p>
-      <h3 className="mt-1 text-sm font-bold leading-snug text-ink-900">
+      <div className="flex items-center gap-2">
+        <Icon size={28} className="shrink-0 text-sea-600" aria-hidden="true" />
+        <p className="text-xs font-bold text-ink-600">
+          {String(number).padStart(2, "0")}
+        </p>
+      </div>
+      <h3 className="mt-2 text-sm font-bold leading-snug text-ink-900">
         {name}
       </h3>
       <p className="mt-0.5 text-xs text-ink-600">{tagline}</p>

--- a/src/app/services/_data.ts
+++ b/src/app/services/_data.ts
@@ -104,11 +104,24 @@ export const PLANS: readonly PlanData[] = [
   },
 ];
 
+export type AISuiteToolIcon =
+  | "BarChart3"
+  | "BadgeJapaneseYen"
+  | "MessageCircle"
+  | "Heart"
+  | "Star"
+  | "Megaphone"
+  | "Settings"
+  | "Receipt"
+  | "Package"
+  | "GraduationCap";
+
 export const AI_SUITE_TOOLS = [
   {
     number: 1,
     name: "AnalyticsAI",
     tagline: "経営データの見える化",
+    icon: "BarChart3" as AISuiteToolIcon,
     tags: ["共通"],
     description:
       "予約数・売上・稼働率をわかりやすいグラフで表示。経営レポートの自動作成や、将来の傾向予測で経営判断をサポートします。",
@@ -117,6 +130,7 @@ export const AI_SUITE_TOOLS = [
     number: 2,
     name: "OptimaPriceAI",
     tagline: "料金の最適化",
+    icon: "BadgeJapaneseYen" as AISuiteToolIcon,
     tags: ["宿泊"],
     description:
       "需要予測をもとに客室料金をリアルタイムで調整。競合の価格動向もモニタリングし、収益を最大化します。",
@@ -125,6 +139,7 @@ export const AI_SUITE_TOOLS = [
     number: 3,
     name: "ConciergeAI",
     tagline: "多言語の自動応答",
+    icon: "MessageCircle" as AISuiteToolIcon,
     tags: ["共通"],
     description:
       "17 言語に対応した自動応答で、ゲストからの問い合わせに 24 時間対応。周辺の観光スポットや飲食店の案内もおまかせください。",
@@ -133,6 +148,7 @@ export const AI_SUITE_TOOLS = [
     number: 4,
     name: "PersonalizeAI",
     tagline: "リピーター育成",
+    icon: "Heart" as AISuiteToolIcon,
     tags: ["共通"],
     description:
       "ゲストの利用履歴をもとにプロファイルを作成し、一人ひとりに合った特典やおすすめを自動で提案。リピーターの獲得につなげます。",
@@ -141,6 +157,7 @@ export const AI_SUITE_TOOLS = [
     number: 5,
     name: "ReputationAI",
     tagline: "口コミ管理",
+    icon: "Star" as AISuiteToolIcon,
     tags: ["共通"],
     description:
       "複数の予約サイトやレビューサイトから口コミを一括収集。感情分析で傾向を把握し、返信文のたたき台も自動生成します。",
@@ -149,6 +166,7 @@ export const AI_SUITE_TOOLS = [
     number: 6,
     name: "MarketingAI",
     tagline: "集客の最適化",
+    icon: "Megaphone" as AISuiteToolIcon,
     tags: ["共通"],
     description:
       "顧客セグメントの分析や、OTA（予約サイト）と自社サイトの使い分け戦略を提案。どこに注力すべきかが見えてきます。",
@@ -157,6 +175,7 @@ export const AI_SUITE_TOOLS = [
     number: 7,
     name: "OperationAI",
     tagline: "業務の自動化",
+    icon: "Settings" as AISuiteToolIcon,
     tags: ["共通"],
     description:
       "スタッフのシフト調整、清掃スケジュールの作成、備品の在庫管理など、日々のオペレーション業務を効率化します。",
@@ -165,6 +184,7 @@ export const AI_SUITE_TOOLS = [
     number: 8,
     name: "AccountingAI",
     tagline: "経理の自動化",
+    icon: "Receipt" as AISuiteToolIcon,
     tags: ["飲食", "共通"],
     description:
       "レシートや請求書を読み取り、仕訳データを自動作成。freee やマネーフォワードとの連携で、手入力の手間を大幅に減らします。",
@@ -173,6 +193,7 @@ export const AI_SUITE_TOOLS = [
     number: 9,
     name: "InventoryAI",
     tagline: "在庫の最適管理",
+    icon: "Package" as AISuiteToolIcon,
     tags: ["飲食", "共通"],
     description:
       "消耗品の使用量を予測し、不足する前に発注を提案。食材ロスの削減にも役立ちます。",
@@ -181,6 +202,7 @@ export const AI_SUITE_TOOLS = [
     number: 10,
     name: "StaffEduAI",
     tagline: "スタッフ教育",
+    icon: "GraduationCap" as AISuiteToolIcon,
     tags: ["共通"],
     description:
       "オンライン学習コンテンツの提供、サービス品質の評価、シミュレーション研修で、スタッフの成長を支援します。",


### PR DESCRIPTION
## 概要
サービスページの AI Suite 10 ツールタイルに、各ツールを象徴する lucide-react アイコンを追加。

closes #76

## 変更内容
- `_data.ts`: `AISuiteToolIcon` 型と各ツールの `icon` フィールドを追加
- `AISuiteToolTile.tsx`: アイコンマップを定義し、番号の左にアイコンを表示（28px、`text-sea-600`）

### アイコン選定
| ツール | アイコン |
|--------|---------|
| AnalyticsAI | BarChart3 |
| OptimaPriceAI | BadgeJapaneseYen |
| ConciergeAI | MessageCircle |
| PersonalizeAI | Heart |
| ReputationAI | Star |
| MarketingAI | Megaphone |
| OperationAI | Settings |
| AccountingAI | Receipt |
| InventoryAI | Package |
| StaffEduAI | GraduationCap |

## テストプラン
- [x] 10 ツール全てにアイコンが表示されている
- [x] 既存の lucide-react アイコンセットと統一感がある
- [x] モバイル表示で崩れない