### PR TITLE
fix(seo): Google Search Console 所有権確認ファイルを追加 (issue#72)

### DIFF
--- a/public/google8187808086bacda7.html
+++ b/public/google8187808086bacda7.html
@@ -1,0 +1,1 @@
+google-site-verification: google8187808086bacda7.html


### PR DESCRIPTION
## 概要

Issue #72 の本番デプロイ残タスクである Google Search Console 登録のための所有権確認ファイルを追加します。

## 変更内容

- `public/google8187808086bacda7.html` を追加
  - Google Search Console が発行した HTML ファイル方式の所有権確認ファイル
  - デプロイ後、`https://ai-landbase.jp/google8187808086bacda7.html` でアクセス可能になる

## 確認手順

マージ後、本番デプロイを行ったうえで以下を実施：

1. ブラウザで `https://ai-landbase.jp/google8187808086bacda7.html` にアクセスして 200 を確認
2. Google Search Console で「確認」ボタンを押す
3. 所有権確認が完了したら sitemap (`https://ai-landbase.jp/sitemap.xml`) を送信

## 関連 Issue

Closes #72 （Search Console 登録完了後）