### PR TITLE
feat(corp): GA4 計測タグを導入 (issue#87)

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -37,3 +37,10 @@ SQUARE_ACCESS_TOKEN=your_square_access_token_here
 SQUARE_APPLICATION_ID=your_square_application_id_here
 SQUARE_LOCATION_ID=your_square_location_id_here
 SQUARE_ENVIRONMENT=sandbox
+
+# ==============================================
+# Google Analytics 4 (任意：開発環境で計測する場合のみ設定)
+# 未設定の場合、GA4 タグはレンダリングされません
+# 取得方法: GA4 管理画面 > 管理 > データストリーム > 該当ストリーム > 測定 ID
+# ==============================================
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/.env.production.example
+++ b/.env.production.example
@@ -48,3 +48,11 @@ NEXTAUTH_SECRET=
 # SQUARE_APPLICATION_ID=your_square_application_id_here
 # SQUARE_LOCATION_ID=your_square_location_id_here
 # SQUARE_ENVIRONMENT=production
+
+# ==============================================
+# Google Analytics 4 (本番環境用)
+# 未設定の場合、GA4 タグはレンダリングされません
+# 取得方法: GA4 管理画面 > 管理 > データストリーム > 該当ストリーム > 測定 ID
+# 値の形式: G-XXXXXXXXXX
+# ==============================================
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs-init",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^16.2.6",
         "@prisma/client": "^7.8.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
@@ -1647,6 +1648,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
+      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9036,6 +9050,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.6",
     "@prisma/client": "^7.8.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",

--- a/projects/ai-landbase-corp/design/handoff/60-implementation-notes.md
+++ b/projects/ai-landbase-corp/design/handoff/60-implementation-notes.md
@@ -533,18 +533,22 @@ JSON-LD on `/about`:
 
 ---
 
-## 11. Analytics (Phase 7 — placeholder note)
+## 11. Analytics
 
-Use `next/script` with `strategy="afterInteractive"` for GA4. Do NOT inject any analytics before page becomes interactive (LCP risk).
+Use the official `@next/third-parties/google` package — its `<GoogleAnalytics>` component is a thin wrapper around `next/script` with `afterInteractive` strategy and ships automatic `page_view` firing on App Router navigation (`usePathname` based). This replaces the earlier `next/script` direct-embed note: same runtime behavior, less code, and avoids hand-rolling the SPA `page_view` re-fire.
 
 ```tsx
-<Script
-  strategy="afterInteractive"
-  src={`https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`}
-/>
+// src/app/layout.tsx
+import { GoogleAnalytics } from "@next/third-parties/google";
+
+const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+// ...
+{gaMeasurementId && <GoogleAnalytics gaId={gaMeasurementId} />}
 ```
 
-CTA-click tracking lives in the `MailtoButton` component — add `onClick` that calls `window.gtag?.('event', 'cta_click', { cta_id })`.
+Guard with `process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID` so the tag is omitted when the variable is unset (dev/preview environments).
+
+CTA-click tracking lives in the `MailtoButton` component — `onClick` calls `window.gtag?.('event', 'cta_click', { cta_id })`. Each call site passes a `ctaId` identifying the location (`header`, `footer`, `hero`, `mobile-nav`, `cta-section-{index}`, `contact-intent-{index}`).
 
 ---
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -59,12 +59,13 @@ export default function ContactPage() {
           ご相談内容をお選びください
         </p>
         <div className="mx-auto grid max-w-[720px] gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {INTENTS.map((intent) => (
+          {INTENTS.map((intent, index) => (
             <MailtoButton
               key={intent.label}
               variant="ghost"
               subject={intent.subject}
               fullWidth
+              ctaId={`contact-intent-${index}`}
             >
               {intent.label}
             </MailtoButton>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_JP, Inter } from "next/font/google";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { SITE_URL, SITE_NAME } from "@/lib/constants";
@@ -45,6 +46,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
   return (
     <html
       lang="ja"
@@ -59,6 +62,7 @@ export default function RootLayout({
           {children}
         </main>
         <Footer />
+        {gaMeasurementId && <GoogleAnalytics gaId={gaMeasurementId} />}
       </body>
     </html>
   );

--- a/src/components/cta/CTASection.tsx
+++ b/src/components/cta/CTASection.tsx
@@ -31,12 +31,13 @@ export function CTASection({
         </h2>
         <p className="mt-4 text-ink-200">{subheading}</p>
         <div className="mt-10 flex flex-col items-center gap-4 md:flex-row md:justify-center">
-          {buttons.map((btn) => (
+          {buttons.map((btn, index) => (
             <MailtoButton
               key={btn.subject}
               variant="onDark"
               size="lg"
               subject={btn.subject}
+              ctaId={`cta-section-${index}`}
             >
               {btn.label}
             </MailtoButton>

--- a/src/components/cta/MailtoButton.tsx
+++ b/src/components/cta/MailtoButton.tsx
@@ -4,6 +4,16 @@ import { useEffect, useState } from "react";
 import { Mail } from "lucide-react";
 import { cn } from "@/lib/cn";
 
+declare global {
+  interface Window {
+    gtag?: (
+      command: string,
+      eventName: string,
+      params?: Record<string, unknown>,
+    ) => void;
+  }
+}
+
 type MailtoButtonProps = {
   subject?: string;
   body?: string;
@@ -11,6 +21,7 @@ type MailtoButtonProps = {
   size?: "md" | "lg";
   fullWidth?: boolean;
   icon?: boolean;
+  ctaId?: string;
   children: React.ReactNode;
 };
 
@@ -24,6 +35,7 @@ export function MailtoButton({
   size = "md",
   fullWidth = false,
   icon = true,
+  ctaId,
   children,
 }: MailtoButtonProps) {
   const [href, setHref] = useState<string | undefined>(undefined);
@@ -35,6 +47,12 @@ export function MailtoButton({
     const qs = params.toString();
     setHref(`mailto:${USER}@${DOMAIN}${qs ? `?${qs}` : ""}`);
   }, [subject, body]);
+
+  const handleClick = ctaId
+    ? () => {
+        window.gtag?.("event", "cta_click", { cta_id: ctaId });
+      }
+    : undefined;
 
   const sizeClass =
     size === "lg" ? "h-13 px-7 text-base" : "h-11 px-5 text-base";
@@ -53,6 +71,7 @@ export function MailtoButton({
   return (
     <Element
       {...(href ? { href } : { type: "button" as const })}
+      onClick={handleClick}
       className={cn(
         "inline-flex items-center justify-center gap-2 rounded-md font-medium",
         "transition-colors duration-150",

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -89,6 +89,7 @@ export function Footer() {
               variant="onDark"
               size="md"
               subject="[AI.LandBase] サービスに関するお問い合わせ"
+              ctaId="footer"
             >
               メールで相談する
             </MailtoButton>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -33,6 +33,7 @@ export function Header() {
             variant="primary"
             size="md"
             subject="[AI.LandBase] サービスに関するお問い合わせ"
+            ctaId="header"
           >
             お問い合わせ
           </MailtoButton>

--- a/src/components/layout/MobileNavSheet.tsx
+++ b/src/components/layout/MobileNavSheet.tsx
@@ -94,6 +94,7 @@ export function MobileNavSheet({ open, onClose }: MobileNavSheetProps) {
             size="lg"
             fullWidth
             subject="[AI.LandBase] サービスに関するお問い合わせ"
+            ctaId="mobile-nav"
           >
             お問い合わせ
           </MailtoButton>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -44,7 +44,12 @@ export function Hero({ variant, headline, lead, imageSrc, cta }: HeroProps) {
             </p>
             {cta && (
               <div className="mt-8">
-                <MailtoButton variant="primary" size="lg" subject={cta.subject}>
+                <MailtoButton
+                  variant="primary"
+                  size="lg"
+                  subject={cta.subject}
+                  ctaId="hero"
+                >
                   {cta.label}
                 </MailtoButton>
                 {cta.caption && (


### PR DESCRIPTION
## Summary
- プライバシーポリシーで宣言済みの GA4 計測タグを導入し、ポリシー・実装の不整合を解消
- Issue #70（Phase 7）からスコープが漏れていた後追い対応
- `@next/third-parties/google` の `<GoogleAnalytics>` を採用(公式パッケージ、page_view 自動発火組み込み)
- CTA クリックトラッキング基盤(`cta_click` イベント)を整備

## 変更内容
- **依存追加**: `@next/third-parties`
- **layout.tsx**: `<GoogleAnalytics>` を body 末尾に配置。`NEXT_PUBLIC_GA_MEASUREMENT_ID` 未設定時は非レンダリング
- **MailtoButton.tsx**: `ctaId` props 追加、`window.gtag` 型宣言、`onClick` で `cta_click` イベント発火
- **MailtoButton 利用箇所 6 か所** に `ctaId` を付与:
  - Header → `header`
  - Footer → `footer`
  - MobileNavSheet → `mobile-nav`
  - Hero → `hero`
  - CTASection → `cta-section-{index}`
  - contact/page → `contact-intent-{index}`
- **環境変数テンプレート**: `.env.development.example` / `.env.production.example` に `NEXT_PUBLIC_GA_MEASUREMENT_ID=` 追加
- **handoff/60-implementation-notes.md**: Analytics セクションを `@next/third-parties` 採用に書き換え、placeholder 表記を解消

## 採用方針
handoff(60-implementation-notes.md:538 元案 = `next/script` 直書き)は placeholder note 表記だったため、Next.js 公式パッケージ `@next/third-parties/google` を採用。peer 互換あり(Next.js 16.2.4 と @next/third-parties 16.2.6)、SPA 遷移での page_view 自動発火が組み込み済みのため受け入れ基準(handoff/50-acceptance-criteria.md:144)を最小コストで達成。

## デプロイ手順
1. このPRをマージ
2. VPS 上の `.env.production` に `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX` を追加(実 ID は別途共有)
3. 本番コンテナをリビルド・再起動
4. GA4 Realtime レポートで page_view が届くことを確認

## Test plan
- [x] `next build` が成功する(型エラーなし、全 13 ページ静的生成)
- [ ] ローカルで `NEXT_PUBLIC_GA_MEASUREMENT_ID` 未設定時にビルド・起動が成功し、タグがレンダリングされないこと
- [ ] ローカルで `NEXT_PUBLIC_GA_MEASUREMENT_ID` 設定時に `gtag/js?id=G-...` が読み込まれること
- [ ] SPA 遷移で page_view が発火する(GA4 Realtime レポート)
- [ ] CTA クリックで `cta_click` イベント発火、`cta_id` パラメータが届く(GA4 DebugView)
- [ ] Lighthouse Performance スコアが低下していない

Closes #87