### PR TITLE
fix(corp): GA4 SPA page_view 発火を自前実装に切り替え (issue#87)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "nextjs-init",
       "version": "0.1.0",
       "dependencies": {
-        "@next/third-parties": "^16.2.6",
         "@prisma/client": "^7.8.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
@@ -1648,19 +1647,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@next/third-parties": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
-      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "third-party-capital": "1.0.20"
-      },
-      "peerDependencies": {
-        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
-        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9050,12 +9036,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/third-party-capital": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
-      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
-      "license": "ISC"
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@next/third-parties": "^16.2.6",
     "@prisma/client": "^7.8.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",

--- a/projects/ai-landbase-corp/design/handoff/60-implementation-notes.md
+++ b/projects/ai-landbase-corp/design/handoff/60-implementation-notes.md
@@ -535,11 +535,13 @@ JSON-LD on `/about`:
 
 ## 11. Analytics
 
-Use the official `@next/third-parties/google` package — its `<GoogleAnalytics>` component is a thin wrapper around `next/script` with `afterInteractive` strategy and ships automatic `page_view` firing on App Router navigation (`usePathname` based). This replaces the earlier `next/script` direct-embed note: same runtime behavior, less code, and avoids hand-rolling the SPA `page_view` re-fire.
+GA4 integration is implemented in `src/components/analytics/GoogleAnalytics.tsx` as a self-contained Client Component. We do not depend on `@next/third-parties/google` — verified empirically that its `<GoogleAnalytics>` does **not** fire `page_view` on App Router SPA navigation (only injects `gtag.js`), so SPA tracking has to be hand-rolled either way. Keeping it in one file avoids the extra dependency.
+
+The component loads `gtag.js` with `next/script` (`strategy="afterInteractive"`, do not inject before page becomes interactive — LCP risk) and inlines the standard init snippet (`window.dataLayer`, `gtag('js', new Date())`, `gtag('config', gaId)`). A nested `PageViewTracker` watches `usePathname()` + `useSearchParams()` and fires `gtag('event', 'page_view', { page_path, page_location, page_title })` on every client-side route change. The first mount is skipped via a `useRef` sentinel because `gtag('config', ...)` already sends the initial `page_view`. `useSearchParams` requires a `<Suspense>` boundary, so the tracker is wrapped.
 
 ```tsx
 // src/app/layout.tsx
-import { GoogleAnalytics } from "@next/third-parties/google";
+import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
 
 const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 // ...
@@ -548,7 +550,7 @@ const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
 Guard with `process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID` so the tag is omitted when the variable is unset (dev/preview environments).
 
-CTA-click tracking lives in the `MailtoButton` component — `onClick` calls `window.gtag?.('event', 'cta_click', { cta_id })`. Each call site passes a `ctaId` identifying the location (`header`, `footer`, `hero`, `mobile-nav`, `cta-section-{index}`, `contact-intent-{index}`).
+CTA-click tracking lives in the `MailtoButton` component — `onClick` calls `window.gtag?.('event', 'cta_click', { cta_id })`. Each call site passes a `ctaId` identifying the location (`header`, `footer`, `hero`, `mobile-nav`, `cta-section-{index}`, `contact-intent-{index}`). The `window.gtag` and `window.dataLayer` types are declared globally in `src/types/gtag.d.ts`.
 
 ---
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_JP, Inter } from "next/font/google";
-import { GoogleAnalytics } from "@next/third-parties/google";
+import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { SITE_URL, SITE_NAME } from "@/lib/constants";

--- a/src/components/analytics/GoogleAnalytics.tsx
+++ b/src/components/analytics/GoogleAnalytics.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Script from "next/script";
+import { Suspense, useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+type Props = {
+  gaId: string;
+};
+
+function PageViewTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = searchParams?.toString() ?? "";
+  const previousPath = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!pathname) return;
+    const url = pathname + (search ? `?${search}` : "");
+
+    if (previousPath.current === null) {
+      previousPath.current = url;
+      return;
+    }
+    if (previousPath.current === url) return;
+    previousPath.current = url;
+
+    window.gtag?.("event", "page_view", {
+      page_path: url,
+      page_location: window.location.href,
+      page_title: document.title,
+    });
+  }, [pathname, search]);
+
+  return null;
+}
+
+export function GoogleAnalytics({ gaId }: Props) {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', ${JSON.stringify(gaId)});
+        `}
+      </Script>
+      <Suspense fallback={null}>
+        <PageViewTracker />
+      </Suspense>
+    </>
+  );
+}

--- a/src/components/analytics/GoogleAnalytics.tsx
+++ b/src/components/analytics/GoogleAnalytics.tsx
@@ -16,6 +16,8 @@ function PageViewTracker() {
 
   useEffect(() => {
     if (!pathname) return;
+    if (typeof window === "undefined" || !window.gtag) return;
+
     const url = pathname + (search ? `?${search}` : "");
 
     if (previousPath.current === null) {
@@ -25,7 +27,7 @@ function PageViewTracker() {
     if (previousPath.current === url) return;
     previousPath.current = url;
 
-    window.gtag?.("event", "page_view", {
+    window.gtag("event", "page_view", {
       page_path: url,
       page_location: window.location.href,
       page_title: document.title,
@@ -36,6 +38,8 @@ function PageViewTracker() {
 }
 
 export function GoogleAnalytics({ gaId }: Props) {
+  if (!gaId) return null;
+
   return (
     <>
       <Script

--- a/src/components/cta/MailtoButton.tsx
+++ b/src/components/cta/MailtoButton.tsx
@@ -4,16 +4,6 @@ import { useEffect, useState } from "react";
 import { Mail } from "lucide-react";
 import { cn } from "@/lib/cn";
 
-declare global {
-  interface Window {
-    gtag?: (
-      command: string,
-      eventName: string,
-      params?: Record<string, unknown>,
-    ) => void;
-  }
-}
-
 type MailtoButtonProps = {
   subject?: string;
   body?: string;

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface Window {
+    gtag?: (
+      command: string,
+      eventName: string,
+      params?: Record<string, unknown>,
+    ) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- PR #89 (Issue #87 の初回対応) で導入した `@next/third-parties/google` の `<GoogleAnalytics>` は、App Router の SPA 遷移で `page_view` を自動発火しないことを実機で確認 (DevTools の `/g/collect` リクエストが初回ロードの 1 件のみ)
- handoff (60-implementation-notes.md:538 の元案) の方針通り、`next/script` + `usePathname` 監視の自前実装に切り替え
- パッケージ依存を 1 つ減らし、GA4 関連コードを 1 ファイルに集約

## 変更内容
- **依存削除**: `@next/third-parties` をアンインストール
- **新規**: `src/components/analytics/GoogleAnalytics.tsx`
  - `next/script` で `gtag.js` を `afterInteractive` 戦略でロード (LCP 保護)
  - インライン init スクリプトで `window.dataLayer` / `gtag('js', new Date())` / `gtag('config', gaId)` を実行
  - `PageViewTracker` 内で `usePathname` + `useSearchParams` を監視し、SPA 遷移時に `gtag('event', 'page_view', { page_path, page_location, page_title })` を発火
  - 初回マウントは `useRef` で識別してスキップ (`gtag('config', ...)` 時の自動 page_view と重複しないため)
  - `useSearchParams` の Suspense 境界つき
  - `gaId` のインライン補間は `JSON.stringify` で安全化
- **新規**: `src/types/gtag.d.ts` に `window.gtag` / `window.dataLayer` の global 型を集約
- **変更**: `src/components/cta/MailtoButton.tsx` から `declare global` を削除 (gtag.d.ts に集約)
- **変更**: `src/app/layout.tsx` のインポートを `@next/third-parties/google` から自作版に差し替え
- **変更**: `design/handoff/60-implementation-notes.md` Section 11 を自前実装方針に更新 (`@next/third-parties` を採用しなかった理由の経緯メモ含む)

## 採用方針
PR #89 では `@next/third-parties/google` が SPA page_view を自動発火するという理解で案 B を採用したが、実機検証 + 公式ドキュメント / ソース再確認の結果、この前提は誤りだった (`<GoogleAnalytics>` は `gtag.js` を注入するのみで、SPA 遷移の page_view 発火は別途実装が必要)。
案 B のまま `usePathname` 監視を追加してもよいが、結局自前実装が必要なので、case として `next/script` 直書きの方が:
- パッケージが 1 個減る
- GA4 関連コードが 1 ファイルにまとまる
- handoff の元案 (60-implementation-notes.md:538) と一致する
で筋がよいと判断し、案 A に戻すリファクタを実施。

## デプロイ手順
1. このPRをマージ
2. VPS で `cd ~/web && git pull origin main`
3. `docker compose -f compose.production.yaml --env-file .env.production up -d --build`
4. GA4 Realtime レポートで SPA 遷移時に複数 page_view が並ぶことを確認

注: `.env.production` の `NEXT_PUBLIC_GA_MEASUREMENT_ID` は PR #89 のデプロイで既に設定済み (今回追加作業なし)

## Test plan
- [x] `next build` が成功する (型エラーなし、全 13 ページ静的生成)
- [ ] DevTools Network タブで SPA 遷移ごとに `/g/collect?v=2&...&dp=/services` 等が **複数件** 発火する
- [ ] GA4 Realtime レポートのページパスリストに `/`, `/services`, `/about` 等が **複数並ぶ**
- [ ] CTA クリック時 `cta_click` イベントが GA4 DebugView に届く (PR #89 から引き続き)
- [ ] Lighthouse Performance スコアが PR #89 時点から低下していない

Closes #87